### PR TITLE
new regex attribute length

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1244,7 +1244,7 @@ class Linter(metaclass=LinterMeta):
             stripped_output = output.replace('\r', '').rstrip()
             persist.printf('{} output:\n{}'.format(self.name, stripped_output))
 
-        for match, line, col, error, warning, message, near in self.find_errors(output):
+        for match, line, col, error, warning, message, near, length in self.find_errors(output):
             if match and message and line is not None:
                 if self.ignore_matches:
                     ignore = False
@@ -1305,8 +1305,11 @@ class Linter(metaclass=LinterMeta):
                         pos = -1
                     else:
                         pos = 0
-
-                    self.highlight.range(line, pos, length=0, error_type=error_type, word_re=self.word_re)
+                        
+                    if length is not None:
+                        self.highlight.range(line, 0, length=length, error_type=error_type, word_re=self.word_re)
+                    else:
+                        self.highlight.range(line, pos, length=0, error_type=error_type, word_re=self.word_re)
 
                 self.error(line, col, message, error_type)
 
@@ -1572,10 +1575,10 @@ class Linter(metaclass=LinterMeta):
         """
 
         if match:
-            items = {'line': None, 'col': None, 'error': None, 'warning': None, 'message': '', 'near': None}
+            items = {'line': None, 'col': None, 'length': None, 'error': None, 'warning': None, 'message': '', 'near': None}
             items.update(match.groupdict())
-            line, col, error, warning, message, near = [
-                items[k] for k in ('line', 'col', 'error', 'warning', 'message', 'near')
+            line, col, length, error, warning, message, near = [
+                items[k] for k in ('line', 'col', 'length', 'error', 'warning', 'message', 'near')
             ]
 
             if line is not None:
@@ -1587,9 +1590,12 @@ class Linter(metaclass=LinterMeta):
                 else:
                     col = len(col)
 
-            return match, line, col, error, warning, message, near
+            if length is not None:
+                length = int(length)
+
+            return match, line, col, error, warning, message, near, length
         else:
-            return match, None, None, None, None, '', None
+            return match, None, None, None, None, '', None, None
 
     def run(self, cmd, code):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1244,7 +1244,14 @@ class Linter(metaclass=LinterMeta):
             stripped_output = output.replace('\r', '').rstrip()
             persist.printf('{} output:\n{}'.format(self.name, stripped_output))
 
-        for match, line, col, error, warning, message, near, length in self.find_errors(output):
+        # To keep backward compatibility and dont break linters that overrides split_match generating
+        # 7 element tuples, we first check the length of the tuple to check if the extra "length" value was passed
+        for error_tuple in self.find_errors(output):
+            if len(error_tuple) == 7:
+                match, line, col, error, warning, message, near = error_tuple
+            elif len(error_tuple) == 8:
+                match, line, col, error, warning, message, near, length = error_tuple
+
             if match and message and line is not None:
                 if self.ignore_matches:
                     ignore = False


### PR DESCRIPTION
This pull request implements "Add multiline highlight (#100)" by basically adding a new attribute to the linter regex called length. If length is not None, then its passed to the highlight.range function (unmodified) that will higlight the a "length" number of characters from the beginning of the line and if this value is grater than the line length, it will continue marking characters in the following line, effectively creating a highlight block similar to the one shown in the issue #100
