### PR TITLE
[on-hold] Multi color

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -6,7 +6,6 @@
         },
         "debug": false,
         "delay": 0.25,
-        "error_color": "D02000",
         "gutter_theme": "Packages/SublimeLinter/gutter-themes/Default/Default.gutter-theme",
         "gutter_theme_excludes": [],
         "lint_mode": "background",
@@ -17,6 +16,10 @@
             "osx": [],
             "windows": []
         },
+        "precedence": [
+            "error",
+            "warning"
+            ],
         "python_paths": {
             "linux": [],
             "osx": [],
@@ -33,7 +36,6 @@
             "html (rails)": "html",
             "php": "html"
         },
-        "warning_color": "DDB700",
         "wrap_find": true
     }
 }

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -19,7 +19,7 @@
         "precedence": [
             "error",
             "warning"
-            ],
+        ],
         "python_paths": {
             "linux": [],
             "osx": [],

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -1,5 +1,9 @@
 {
     "default": {
+        "colors":{
+            "error":"D02000",
+            "warning":"DDB700"
+        },
         "debug": false,
         "delay": 0.25,
         "error_color": "D02000",

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -297,15 +297,16 @@ class Highlight:
         region = sublime.Region(pos, pos + length)
         region_coords = (region.a, region.b)
 
-        if region_coords in self.coordinates:
+        try:
             current_type = self.coordinates[region_coords]
 
             if more_important(error_type, current_type):
                 self.marks[current_type].remove(region)
             else:
-                # entry is either MORE important than us
-                # or precedence was undefined but it was made first
                 return
+
+        except KeyError:
+            pass
 
         self.coordinates[region_coords] = error_type
         self.marks[error_type].append(region)
@@ -417,7 +418,7 @@ class Highlight:
                     if more_important(mark_type, existing_type):
                         self.marks[existing_type].remove(mark)
                     else:
-                        pass
+                        continue
 
                 self.marks[mark_type].append(mark)
                 self.coordinates[new_coord] = mark_type
@@ -453,9 +454,9 @@ class Highlight:
 
     def fix_icon(self, mark_type):
         """Return appropriate icon file path--generating the file if necessary."""
-        if mark_type in self.icon_generators:
+        try:
             return next(self.icon_generators[mark_type])
-        else:
+        except KeyError:
 
             def iconerator(mark_type):
                 """Return an icon generator for a given mark_type."""

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -237,7 +237,6 @@ class Highlight:
             subtype = next(parts)
 
             while subtype:
-
                 if subtype in colors:
                     specific_type = '{}.{}'.format(self.linter_name, subtype)
 
@@ -408,13 +407,11 @@ class Highlight:
         """
         # merge following precedence rules
         for mark_type in other.marks:
-
             for mark in other.marks[mark_type]:
                 new_coord = (mark.a, mark.b)
                 existing_type = self.coordinates.get(new_coord)
 
                 if existing_type:
-
                     if more_important(mark_type, existing_type):
                         self.marks[existing_type].remove(mark)
                     else:
@@ -428,10 +425,8 @@ class Highlight:
             current_type = self.lines.get(line)
 
             if current_type:
-
                 if more_important(mark_type, current_type):
                     self.lines[line] = mark_type
-
             else:
                 self.lines[line] = mark_type
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -238,9 +238,8 @@ class Linter(metaclass=LinterMeta):
     # If you want to set flags on the regex *other* than re.MULTILINE, set this.
     re_flags = 0
 
-    # The default type assigned to non-classified errors. Should be either
-    # highlight.ERROR or highlight.WARNING.
-    default_type = highlight.ERROR
+    # The default type assigned to non-classified errors.
+    default_type = highlight.DEFAULT_MARK
 
     # Linters usually report errors with a line number, some with a column number
     # as well. In general, most linters report one-based line numbers and column
@@ -445,8 +444,6 @@ class Linter(metaclass=LinterMeta):
         """
 
         settings = self.get_merged_settings()
-        print("OH HAY SETTINGS")
-        print(settings)
 
         if not no_inline:
             inline_settings = {}
@@ -940,6 +937,7 @@ class Linter(metaclass=LinterMeta):
         """Reset a linter to work on the given code and filename."""
         self.errors = {}
         self.code = code
+        self.clear()
         self.highlight = highlight.Highlight(self.code, linter_name=self.name)
 
         if self.ignore_matches is None:
@@ -1271,6 +1269,7 @@ class Linter(metaclass=LinterMeta):
                     if ignore:
                         continue
 
+                # TODO - sane way for linters to report complex mark types
                 if error:
                     error_type = highlight.ERROR
                 elif warning:
@@ -1322,7 +1321,7 @@ class Linter(metaclass=LinterMeta):
         """Clear marks, status and all other cached error info for the given view."""
 
         view.erase_status('sublimelinter')
-        highlight.Highlight.clear(view)
+        highlight.HighlightSet.clear(view)
 
         if view.id() in persist.errors:
             del persist.errors[view.id()]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -392,7 +392,7 @@ class Linter(metaclass=LinterMeta):
         self.view = view
         self.syntax = syntax
         self.code = ''
-        self.highlight = highlight.Highlight()
+        self.highlight = highlight.Highlight(linter_name=self.name)
         self.ignore_matches = None
 
     @property
@@ -445,6 +445,8 @@ class Linter(metaclass=LinterMeta):
         """
 
         settings = self.get_merged_settings()
+        print("OH HAY SETTINGS")
+        print(settings)
 
         if not no_inline:
             inline_settings = {}
@@ -938,7 +940,7 @@ class Linter(metaclass=LinterMeta):
         """Reset a linter to work on the given code and filename."""
         self.errors = {}
         self.code = code
-        self.highlight = highlight.Highlight(self.code)
+        self.highlight = highlight.Highlight(self.code, linter_name=self.name)
 
         if self.ignore_matches is None:
             ignore_match = settings.get('ignore_match')

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -351,6 +351,7 @@ class Settings:
                 ' and the default is also not available. '
                 'No gutter marks will display.'.format(theme)
             )
+
             for mark_type in [x for x in gutter_marks if x is not 'colorize']:
                 gutter_marks[mark_type] = ''
 
@@ -365,7 +366,6 @@ class Settings:
 
         # enumerate for linters
         for linter_name, linter_settings in self.get('linters', {}).items():
-
             for mark_type, color in linter_settings.get('colors', {}).items():
                 colors[mark_type]['{}.{}'.format(linter_name, mark_type)] = color
 

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -328,8 +328,7 @@ class Settings:
                 pass
 
         if info is not None:
-            print("holy infoz, batmens")
-            print(info)
+            
             if theme != 'Default' and os.path.basename(path) == 'Default.gutter-theme':
                 printf('cannot find the gutter theme \'{}\', using the default'.format(theme))
 

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -203,7 +203,7 @@ class Settings:
                     'Would you like to update the user color schemes '
                     'with the new colors?')
             ):
-                util.update_mark_colors()
+                util.generate_color_scheme()
 
         if (
             ('error_color' in self.changeset or 'warning_color' in self.changeset) or

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -328,7 +328,7 @@ class Settings:
                 pass
 
         if info is not None:
-            
+
             if theme != 'Default' and os.path.basename(path) == 'Default.gutter-theme':
                 printf('cannot find the gutter theme \'{}\', using the default'.format(theme))
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -236,7 +236,6 @@ def generate_color_scheme_async():
     styles = plist.find('./dict/array')
 
     for mark_type, codes in merged_colors.items():
-
         for context, code in codes.items():
             styles.append(
                 ElementTree.XML(COLOR_SCHEME_STYLES['color'].format(name=context, title=context.title(), color=code))

--- a/lint/util.py
+++ b/lint/util.py
@@ -214,9 +214,9 @@ def generate_color_scheme_async():
     if scheme is None:
         return
 
-    # this is a non-linter-version scheme (i.e., the user just picked one)
+    # This is a non-linter-version scheme (i.e., the user just picked one).
     if scheme.find(" (SL)") == -1:
-        # so, set their choice as the base scheme
+        # So set their choice as the base scheme.
         prefs.set('base_color_scheme', scheme)
         base_scheme = scheme
     else:
@@ -225,9 +225,9 @@ def generate_color_scheme_async():
     scheme_text = sublime.load_resource(base_scheme)
     merged_colors = persist.settings.colors()
 
-    # We used to decide whether or not to write based on whether or not
+    # We used to decide whether or not to write based on whether
     # we detected updates via regex. Now that we don't know for sure what
-    # the message types are, there's no clear way to know if one has gone
+    # the mark types are, there's no clear way to know if one has gone
     # missing. The easiest way to stay up-to-date is to just re-generate
     # from our source template each time.
 
@@ -236,6 +236,7 @@ def generate_color_scheme_async():
     styles = plist.find('./dict/array')
 
     for mark_type, codes in merged_colors.items():
+
         for context, code in codes.items():
             styles.append(
                 ElementTree.XML(COLOR_SCHEME_STYLES['color'].format(name=context, title=context.title(), color=code))
@@ -247,13 +248,14 @@ def generate_color_scheme_async():
     # Write the amended color scheme to Packages/User
     original_name = os.path.splitext(os.path.basename(scheme))[0]
     name = original_name
+
     if not original_name.endswith(' (SL)'):
         name = original_name + ' (SL)'
+
     scheme_path = os.path.join(sublime.packages_path(), 'User', name + '.tmTheme')
 
-    with open(scheme_path, 'w', encoding='utf8') as f:
-        f.write(COLOR_SCHEME_PREAMBLE)
-        f.write(ElementTree.tostring(plist, encoding='unicode'))
+    with open(scheme_path+"temp", 'w', encoding='utf8') as f:
+        f.write(COLOR_SCHEME_PREAMBLE + ElementTree.tostring(plist, encoding='unicode'))
 
     # Set the amended color scheme to the current color scheme
     path = os.path.join('User', os.path.basename(scheme_path))

--- a/lint/util.py
+++ b/lint/util.py
@@ -209,7 +209,7 @@ def generate_color_scheme_async():
     from . import persist
     prefs = sublime.load_settings('Preferences.sublime-settings')
     scheme = prefs.get('color_scheme')
-    base_scheme = scheme
+    base_scheme = None
 
     if scheme is None:
         return
@@ -220,7 +220,7 @@ def generate_color_scheme_async():
         prefs.set('base_color_scheme', scheme)
         base_scheme = scheme
     else:
-        base_scheme = prefs.get('base_color_scheme')
+        base_scheme = prefs.get('base_color_scheme', scheme)
 
     scheme_text = sublime.load_resource(base_scheme)
     merged_colors = persist.settings.colors()

--- a/lint/util.py
+++ b/lint/util.py
@@ -253,7 +253,7 @@ def generate_color_scheme_async():
 
     scheme_path = os.path.join(sublime.packages_path(), 'User', name + '.tmTheme')
 
-    with open(scheme_path+"temp", 'w', encoding='utf8') as f:
+    with open(scheme_path, 'w', encoding='utf8') as f:
         f.write(COLOR_SCHEME_PREAMBLE + ElementTree.tostring(plist, encoding='unicode'))
 
     # Set the amended color scheme to the current color scheme

--- a/lint/util.py
+++ b/lint/util.py
@@ -214,22 +214,19 @@ def generate_color_scheme_async():
     if scheme is None:
         return
 
-    #this is a non-linter-version scheme (i.e., the user just picked one)
+    # this is a non-linter-version scheme (i.e., the user just picked one)
     if scheme.find(" (SL)") == -1:
-        #so, set the base
+        # so, set their choice as the base scheme
         prefs.set('base_color_scheme', scheme)
         base_scheme = scheme
     else:
         base_scheme = prefs.get('base_color_scheme')
 
     scheme_text = sublime.load_resource(base_scheme)
-
-    # Ensure that all SublimeLinter colors are in the scheme
     merged_colors = persist.settings.colors()
-    sl_colors = persist.settings.get('colors', {})
 
     # We used to decide whether or not to write based on whether or not
-    # we detected updates via regex. Now that we don't know for sure what 
+    # we detected updates via regex. Now that we don't know for sure what
     # the message types are, there's no clear way to know if one has gone
     # missing. The easiest way to stay up-to-date is to just re-generate
     # from our source template each time.
@@ -238,16 +235,14 @@ def generate_color_scheme_async():
     plist = ElementTree.XML(scheme_text)
     styles = plist.find('./dict/array')
 
-    for mark_type, code in sl_colors.items():
-        styles.append(ElementTree.XML(COLOR_SCHEME_STYLES['color'].format(name=mark_type, title=mark_type.title(), color=code)))
-
     for mark_type, codes in merged_colors.items():
         for context, code in codes.items():
-            styles.append(ElementTree.XML(COLOR_SCHEME_STYLES['color'].format(name=context, title=context.title(), color=code)))
+            styles.append(
+                ElementTree.XML(COLOR_SCHEME_STYLES['color'].format(name=context, title=context.title(), color=code))
+                )
 
-    for style in ["gutter"]:
-        color = persist.settings.get('{}_color'.format(style), DEFAULT_MARK_COLORS[style]).lstrip('#')
-        styles.append(ElementTree.XML(COLOR_SCHEME_STYLES[style].format(color)))
+    color = persist.settings.get('{}_color'.format("gutter"), DEFAULT_MARK_COLORS["gutter"]).lstrip('#')
+    styles.append(ElementTree.XML(COLOR_SCHEME_STYLES["gutter"].format(color)))
 
     # Write the amended color scheme to Packages/User
     original_name = os.path.splitext(os.path.basename(scheme))[0]
@@ -264,7 +259,6 @@ def generate_color_scheme_async():
     path = os.path.join('User', os.path.basename(scheme_path))
     prefs.set('color_scheme', packages_relative_path(path))
     sublime.save_settings('Preferences.sublime-settings')
-    print("ACTUALLY UPDATING COLOR SCHEME")
 
 
 def change_mark_colors(error_color, warning_color):
@@ -1325,8 +1319,7 @@ def center_region_in_view(region, view):
 
 
 # color-related constants
-
-DEFAULT_MARK_COLORS = {'warning': 'EDBA00', 'error': 'DA2000', 'gutter': 'FFFFFF'}
+DEFAULT_MARK_COLORS = {'gutter': 'FFFFFF'}
 
 COLOR_SCHEME_PREAMBLE = '''<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1343,34 +1336,6 @@ COLOR_SCHEME_STYLES = {
             <dict>
                 <key>foreground</key>
                 <string>#{color}</string>
-            </dict>
-        </dict>
-    ''',
-    
-    'warning': '''
-        <dict>
-            <key>name</key>
-            <string>SublimeLinter Warning</string>
-            <key>scope</key>
-            <string>sublimelinter.mark.warning</string>
-            <key>settings</key>
-            <dict>
-                <key>foreground</key>
-                <string>#{}</string>
-            </dict>
-        </dict>
-    ''',
-
-    'error': '''
-        <dict>
-            <key>name</key>
-            <string>SublimeLinter Error</string>
-            <key>scope</key>
-            <string>sublimelinter.mark.error</string>
-            <key>settings</key>
-            <dict>
-                <key>foreground</key>
-                <string>#{}</string>
             </dict>
         </dict>
     ''',

--- a/lint/util.py
+++ b/lint/util.py
@@ -209,7 +209,7 @@ def generate_color_scheme_async():
     from . import persist
     prefs = sublime.load_settings('Preferences.sublime-settings')
     scheme = prefs.get('color_scheme')
-    base_scheme = None
+    base_scheme = scheme
 
     if scheme is None:
         return

--- a/lint/util.py
+++ b/lint/util.py
@@ -264,6 +264,7 @@ def generate_color_scheme_async():
 
 
 def change_mark_colors(error_color, warning_color):
+    """Change SublimeLinter error/warning colors in user color schemes."""
     raise DeprecationWarning("change_mark_colors has been deprecated; generate_color_scheme is an indrect replacement.")
 
 


### PR DESCRIPTION
Implements flexible mark types and mark-type color settings.

Global color settings may be defined under 'colors'; linter-specific colors may be defined in a 'colors' setting under a given linter. Internally the main driver is that marks are now scoped by linter (i.e., 'annotations.warning' or 'pylint.error') and then the complexity is reduced from left to right in search of the nearest reasonable setting. 

Previously the rules for mark priority were pretty simple. I've also introduced a 'precedence' setting which is a list of scopes from most to least important. If the precedence setting is insufficient for resolving a conflict, precedence is granted to the first mark made.

This changeset was larger and touched a lot more of the code than I was expecting; I don't imagine this will go through clean on the first try, so I'll be looking forward to your thoughts.
