### PR TITLE
Fix an infinite loop in windows.

### DIFF
--- a/lint/node_linter.py
+++ b/lint/node_linter.py
@@ -159,7 +159,7 @@ class NodeLinter(linter.Linter):
 
         parent = path.normpath(path.join(cwd, '../'))
 
-        if parent == '/':
+        if parent == '/' or parent == cwd:
             return None
 
         return self.rev_parse_manifest_path(parent)


### PR DESCRIPTION
Since the root level directory in windows is not “/“, this function
would never resolve if if could not find a manifest file (package.json).