### PR TITLE
Indent 2 spaces for YAML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
Specify an indent size of 2 spaces for paths matching *.yml.