### PR TITLE
Don't exclude __init__.py and linter-plugin-template from flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pip install pep257
 # command to run tests
 script:
-  - flake8 . --max-line-length=120 --exclude=__init__.py,linter-plugin-template
+  - flake8 . --max-line-length=120 --exclude=__init__.py
   - pep257 . --ignore=D202

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pip install pep257
 # command to run tests
 script:
-  - flake8 . --max-line-length=120 --exclude=__init__.py
+  - flake8 . --max-line-length=120
   - pep257 . --ignore=D202

--- a/commands.py
+++ b/commands.py
@@ -838,7 +838,7 @@ class SublimelinterCreateLinterPluginCommand(sublime_plugin.WindowCommand):
             '__class__': self.camel_case(name),
             '__superclass__': info.get('superclass', 'Linter'),
             '__cmd__': '{}@python'.format(name) if language == 'python' else name,
-            '__extra_attributes__': extra_attributes,
+            '# __extra_attributes__': extra_attributes,
             '__platform__': platform,
             '__install__': info['installer'].format(name),
             '__extra_install_steps__': extra_steps

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -1,4 +1,4 @@
-# [sublimelinter flake8-ignore:F401]
+# flake8: noqa
 #
 # lint.__init__
 # Part of SublimeLinter3, a code checking framework for Sublime Text 3

--- a/linter-plugin-template/linter.py
+++ b/linter-plugin-template/linter.py
@@ -33,4 +33,4 @@ class __class__(__superclass__):
     defaults = {}
     inline_settings = None
     inline_overrides = None
-    __extra_attributes__
+    # __extra_attributes__


### PR DESCRIPTION
The only error in `linter-plugin-template/linter.py` is the undefined variable `__extra_attributes__`, which could easily just be a comment.

We also don't want to exclude _all_ files named `__init__.py` since there will likely be others when we add unit tests, only `lint/__init__.py`, which is better done with a flake8 pragma in the file itself.