### PR TITLE
demote_to_warning_match setting

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -393,6 +393,7 @@ class Linter(metaclass=LinterMeta):
         self.code = ''
         self.highlight = highlight.Highlight()
         self.ignore_matches = None
+        self.demote_to_warning_matches = None
 
     @property
     def filename(self):
@@ -887,6 +888,7 @@ class Linter(metaclass=LinterMeta):
             # We compile the ignore matches for a linter on each run,
             # clear the cache first.
             linter.ignore_matches = None
+            linter.demote_to_warning_matches = None
 
             if view_settings.get('@disable'):
                 disabled.add(linter)
@@ -1006,6 +1008,63 @@ class Linter(metaclass=LinterMeta):
         else:
             return []
 
+    def compile_demote_to_warning_match(self, pattern):
+        """Return the compiled pattern, log the error if compilation fails."""
+        try:
+            return re.compile(pattern)
+        except re.error as err:
+            persist.printf(
+                'ERROR: {}: invalid demote_to_warning_match: "{}" ({})'
+                .format(self.name, pattern, str(err))
+            )
+            return None
+
+    def compiled_demote_to_warning_matches(self, demote_to_warning_match):
+        """
+        Compile the "demote_to_warning_match" linter setting as an optimization.
+
+        If it's a string, return a list with a single compiled regex.
+        If it's a list, return a list of the compiled regexes.
+        If it's a dict, return a list only of the regexes whose key
+        matches the file's extension.
+
+        """
+
+        if isinstance(demote_to_warning_match, str):
+            regex = self.compile_demote_to_warning_match(demote_to_warning_match)
+            return [regex] if regex else []
+
+        elif isinstance(demote_to_warning_match, list):
+            matches = []
+
+            for match in demote_to_warning_match:
+                regex = self.compile_demote_to_warning_match(match)
+
+                if regex:
+                    matches.append(regex)
+
+            return matches
+
+        elif isinstance(demote_to_warning_match, dict):
+            if not self.filename:
+                return []
+
+            ext = os.path.splitext(self.filename)[1].lower()
+
+            if not ext:
+                return []
+
+            # Try to match the extension, then the extension without the dot
+            demote_to_warning_match = demote_to_warning_match.get(ext, demote_to_warning_match.get(ext[1:]))
+
+            if demote_to_warning_match:
+                return self.compiled_demote_to_warning_matches(demote_to_warning_match)
+            else:
+                return []
+
+        else:
+            return []
+
     def reset(self, code, settings):
         """Reset a linter to work on the given code and filename."""
         self.errors = {}
@@ -1019,6 +1078,14 @@ class Linter(metaclass=LinterMeta):
                 self.ignore_matches = self.compiled_ignore_matches(ignore_match)
             else:
                 self.ignore_matches = []
+
+        if self.demote_to_warning_matches is None:
+            demote_to_warning_match = settings.get('demote_to_warning_match')
+
+            if demote_to_warning_match:
+                self.demote_to_warning_matches = self.compiled_demote_to_warning_matches(demote_to_warning_match)
+            else:
+                self.demote_to_warning_matches = []
 
     @classmethod
     def which(cls, cmd):
@@ -1346,7 +1413,29 @@ class Linter(metaclass=LinterMeta):
                         continue
 
                 if error:
-                    error_type = highlight.ERROR
+                    demote_to_warning = False
+
+                    if self.demote_to_warning_matches:
+                        for demote_to_warning_match in self.demote_to_warning_matches:
+                            if demote_to_warning_match.match(message):
+                                demote_to_warning = True
+
+                            if persist.debug_mode():
+                                persist.printf(
+                                    '{} ({}): demote_to_warning_match: "{}" == "{}"'
+                                    .format(
+                                        self.name,
+                                        os.path.basename(self.filename) or '<unsaved>',
+                                        demote_to_warning_match.pattern,
+                                        message
+                                    )
+                                )
+                            break
+
+                    if demote_to_warning:
+                        error_type = highlight.WARNING
+                    else:
+                        error_type = highlight.ERROR
                 elif warning:
                     error_type = highlight.WARNING
                 else:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1413,6 +1413,13 @@ class Linter(metaclass=LinterMeta):
                         continue
 
                 if error:
+                    error_type = highlight.ERROR
+                elif warning:
+                    error_type = highlight.WARNING
+                else:
+                    error_type = self.default_type
+
+                if error_type is highlight.ERROR:
                     demote_to_warning = False
 
                     if self.demote_to_warning_matches:
@@ -1434,12 +1441,6 @@ class Linter(metaclass=LinterMeta):
 
                     if demote_to_warning:
                         error_type = highlight.WARNING
-                    else:
-                        error_type = highlight.ERROR
-                elif warning:
-                    error_type = highlight.WARNING
-                else:
-                    error_type = self.default_type
 
                 if col is not None:
                     start, end = self.highlight.full_line(line)


### PR DESCRIPTION
Added the new setting "demote_to_warning_match" to each linter's preferences. It works almost exactly the same as the "ignore_match" preference, but instead of ignoring the errors it catches, it only demotes them to warnings instead.

I have been using this together with silent_warnings and lint_mode on save for some time, specifically with luacheck, demoting the "unused argument" error to a warning.