### PR TITLE
Removed invisible characters in "template" word

### DIFF
--- a/fixed-syntaxes/HTML/HTML.tmLanguage
+++ b/fixed-syntaxes/HTML/HTML.tmLanguage
@@ -305,7 +305,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:temp‌​late|html)['"])</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?!.*type=["']text/(?:template|html)['"])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Trust me or not, but there are some hidden characters in "template" word between "p" and "l" :)  I can't even see them in Sublime, but they are really there and script type='text/template' doesn't work as it should. It works only if you copy "template" word from SublimeLinter\fixed-syntaxes\HTML\HTML.tmLanguage directly. They can be seen in GitHub Editor, though. Removed them...

![screenshot](https://cloud.githubusercontent.com/assets/1658020/6825514/2f73f556-d30c-11e4-80c9-0f8713fcea16.png)
