### PR TITLE
detect new syntax definition file format .sublime-syntax

### DIFF
--- a/lint/persist.py
+++ b/lint/persist.py
@@ -32,7 +32,7 @@ LINT_MODES = (
     ('manual', 'Lint only when requested')
 )
 
-SYNTAX_RE = re.compile(r'(?i)/([^/]+)\.tmLanguage$')
+SYNTAX_RE = re.compile(r'(?i)/([^/]+)\.(?:tmLanguage|sublime-syntax)$')
 
 DEFAULT_GUTTER_THEME_PATH = 'Packages/SublimeLinter/gutter-themes/Default/Default.gutter-theme'
 


### PR DESCRIPTION
Sublime Text build 3084 introduced a new syntax definition format [.sublime-syntax](http://www.sublimetext.com/docs/3/syntax.html). Views that use 
this new format are currently not detected by sublime linter. This patch solves that issue.