### PR TITLE
Only return tmpfile_suffix if the view does not have a file name

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1785,7 +1785,7 @@ class Linter(metaclass=LinterMeta):
 
     def get_tempfile_suffix(self):
         """Return the mapped tempfile_suffix."""
-        if self.tempfile_suffix:
+        if self.tempfile_suffix and not self.view.file_name():
             if isinstance(self.tempfile_suffix, dict):
                 suffix = self.tempfile_suffix.get(persist.get_syntax(self.view), self.syntax)
             else:


### PR DESCRIPTION
Some syntax definitions can support multiple file extensions. If the file already has a file extension we should use it, otherwise we can try and guess.