### PR TITLE
demote_to_warning_match only checks for the first pattern

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1427,17 +1427,18 @@ class Linter(metaclass=LinterMeta):
                             if demote_to_warning_match.match(message):
                                 demote_to_warning = True
 
-                            if persist.debug_mode():
-                                persist.printf(
-                                    '{} ({}): demote_to_warning_match: "{}" == "{}"'
-                                    .format(
-                                        self.name,
-                                        os.path.basename(self.filename) or '<unsaved>',
-                                        demote_to_warning_match.pattern,
-                                        message
+                                if persist.debug_mode():
+                                    persist.printf(
+                                        '{} ({}): demote_to_warning_match: "{}" == "{}"'
+                                        .format(
+                                            self.name,
+                                            os.path.basename(self.filename) or '<unsaved>',
+                                            demote_to_warning_match.pattern,
+                                            message
+                                        )
                                     )
-                                )
-                            break
+                                    
+                                break
 
                     if demote_to_warning:
                         error_type = highlight.WARNING


### PR DESCRIPTION
demote_to_warning_match would only check for the first pattern in the list instead of all patterns in the list. Indentation on a for-if-break was wrong, making it break out of the for on the first loop.