### PR TITLE
Changing save and manual linting to async mode, to prevent UI freeze.

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -93,7 +93,7 @@ class SublimelinterLintCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         """Lint the current view."""
         from .sublimelinter import SublimeLinter
-        SublimeLinter.shared_plugin().lint(self.view.id())
+        SublimeLinter.shared_plugin().hit(self.view)
 
 
 class HasErrorsCommand:

--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -92,10 +92,8 @@ class SublimeLinter(sublime_plugin.EventListener):
         """
         Lint the view with the given id.
 
-        This method is called asynchronously by persist.Daemon when a lint
-        request is pulled off the queue, or called synchronously when the
-        Lint command is executed or a file is saved and Show Errors on Save
-        is enabled.
+        This method is called asynchronously by queue.Daemon when a lint
+        request is pulled off the queue.
 
         If provided, hit_time is the time at which the lint request was added
         to the queue. It is used to determine if the view has been modified
@@ -456,7 +454,7 @@ class SublimeLinter(sublime_plugin.EventListener):
 
             if vid in persist.view_linters:
                 if mode != 'manual':
-                    self.lint(vid)
+                    self.hit(view)
                 else:
                     show_errors = False
             else:
@@ -467,7 +465,7 @@ class SublimeLinter(sublime_plugin.EventListener):
                 mode in ('load/save', 'save only') or
                 mode == 'background' and self.view_has_file_only_linter(vid)
             ):
-                self.lint(vid)
+                self.hit(view)
             elif mode == 'manual':
                 show_errors = False
 


### PR DESCRIPTION
Adapted all modes of linting to use the queue.Daemon task queue,
including 'load/save', 'save only' and 'manual'. This prevents slow
linters from blocking the interface (e.g. pylint).