### PR TITLE
SUBLIME_LINTER_FILE and SUBLIME_LINTER_FOLDERS env variables

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -360,7 +360,7 @@ class Linter(metaclass=LinterMeta):
     errors = None
     highlight = None
     lint_settings = None
-    env = None
+    env = {}
     disabled = False
     executable_version = None
 
@@ -394,6 +394,9 @@ class Linter(metaclass=LinterMeta):
         self.highlight = highlight.Highlight()
         self.ignore_matches = None
         self.demote_to_warning_matches = None
+
+        self.env['SUBLIME_LINTER_FILE'] = self.filename
+        self.env['SUBLIME_LINTER_FOLDERS'] = ';'.join(self.view.window().folders())
 
     @property
     def filename(self):


### PR DESCRIPTION
Hi all!

[I'm using the docker container for eslint](https://github.com/kkamkou/docker-applications/blob/master/eslint.sh). The only problem is to extract the root folder from the sublime tree. This path is required for `.eslintrc` detection.

What I did is kind of sharing the information using the ENV variables. Please, review.

p.s. tests are not working with the latest version of py.test