### PR TITLE
Add "JavaScript (babel)" to syntax map

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -28,6 +28,7 @@
             "html 5": "html",
             "html (django)": "html",
             "html (rails)": "html",
+            "javascript (babel)": "javascript",
             "php": "html"
         },
         "warning_color": "DDB700",


### PR DESCRIPTION
https://github.com/babel/babel-sublime has been gaining in popularity in the JS community. Would be good to get it mapped in by default.

Thx very much for SL!