### PR TITLE
new linter setting -- `chdir`

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -120,3 +120,29 @@ In :ref:`debug mode <debug-mode>`, |sl| logs each occurrence of an ignore match.
 .. note::
 
    |regex|
+
+
+chdir
+-----
+This setting specifies the linter working directory.
+
+The value must be a string, corresponding to a valid directory path.
+
+.. code-block:: json
+
+    {
+        "chdir": "${project}",
+    {
+
+With the above example, the linter will get invoked from the ``${project}`` directory (see :ref:`Inline overrides <_settings-tokens>` for more info on using tokens).
+
+.. note::
+
+     If the value of ``chdir`` is unspecified (or inaccessible), then:
+
+     - If linting an unsaved file, the directory is unchanged
+
+     - If linting a saved file, the directory is set to that of the linted file
+
+
+

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1373,7 +1373,7 @@ class Linter(metaclass=LinterMeta):
             else:
                 self.chdir = os.path.realpath('.')
 
-            persist.printf('chdir not set or invalid, using %s' % self.chdir)
+            persist.debug('chdir not set or invalid, using %s' % self.chdir)
 
         with util.cd(self.chdir):
             output = self.run(cmd, self.code)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1364,24 +1364,19 @@ class Linter(metaclass=LinterMeta):
             if cmd is not None and not cmd:
                 return
 
-        cwd = None
+        settings = self.get_view_settings()
+        self.chdir = settings.get('chdir', None)
 
-        if self.filename:
-            try:
-                cwd = os.getcwd()
-            except OSError:
-                pass
+        if not self.chdir or not os.path.isdir(self.chdir):
+            if self.filename:
+                self.chdir = os.path.dirname(self.filename)
+            else:
+                self.chdir = os.path.realpath('.')
 
-            try:
-                os.chdir(os.path.dirname(self.filename))
-            except OSError:
-                # If chdir fails, there's no need to chdir back later on
-                cwd = None
+            persist.printf('chdir not set or invalid, using %s' % self.chdir)
 
-        output = self.run(cmd, self.code)
-
-        if cwd:
-            os.chdir(cwd)
+        with util.cd(self.chdir):
+            output = self.run(cmd, self.code)
 
         if not output:
             return
@@ -1726,7 +1721,6 @@ class Linter(metaclass=LinterMeta):
 
         if self.multiline:
             errors = self.regex.finditer(output)
-
             if errors:
                 for error in errors:
                     yield self.split_match(error)

--- a/lint/util.py
+++ b/lint/util.py
@@ -1380,6 +1380,21 @@ def center_region_in_view(region, view):
         view.show_at_center(region)
 
 
+class cd:
+
+    """Context manager for changing the current working directory."""
+
+    def __init__(self, newPath):
+        self.newPath = os.path.expanduser(newPath)
+
+    def __enter__(self):
+        self.savedPath = os.getcwd()
+        os.chdir(self.newPath)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.savedPath)
+
+
 # color-related constants
 
 DEFAULT_MARK_COLORS = {'warning': 'EDBA00', 'error': 'DA2000', 'gutter': 'FFFFFF'}

--- a/lint/util.py
+++ b/lint/util.py
@@ -1385,13 +1385,16 @@ class cd:
     """Context manager for changing the current working directory."""
 
     def __init__(self, newPath):
+        """Save the new wd."""
         self.newPath = os.path.expanduser(newPath)
 
     def __enter__(self):
+        """Save the old wd and change to the new wd."""
         self.savedPath = os.getcwd()
         os.chdir(self.newPath)
 
     def __exit__(self, etype, value, traceback):
+        """Go back to the old wd."""
         os.chdir(self.savedPath)
 
 


### PR DESCRIPTION
Allows to specify a linter's working directory (#150).
In case a value is not set or is invalid, the old behavior is used (try to change to the directory of the linted file).
