### PR TITLE
Recognize MagicPython as Python with default settings

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -25,6 +25,7 @@
         "show_marks_in_minimap": true,
         "syntax_map": {
             "python django": "python",
+            "magicpython": "python",
             "html 5": "html",
             "html (django)": "html",
             "html (rails)": "html",


### PR DESCRIPTION
First of all, thanks for the amazing package!

A number of [MagicPython](https://github.com/MagicStack/MagicPython) users struggling to enable Sublime Linter for it.  This PR adds it to `"syntax_map"` in the default config.