### PR TITLE
Relax color scheme check to a reasonable level

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -50,6 +50,8 @@ MARK_COLOR_RE = (
     r'(\s*<string>sublimelinter\.{}</string>\s*\r?\n'
     r'\s*<key>settings</key>\s*\r?\n'
     r'\s*<dict>\s*\r?\n'
+    r'(?:\s*<key>(?:background|fontStyle)</key>\s*\r?\n'
+    r'\s*<string>.*?</string>\r?\n)*'
     r'\s*<key>foreground</key>\s*\r?\n'
     r'\s*<string>)#.+?(</string>\s*\r?\n)'
 )


### PR DESCRIPTION
SublimeLinter shouldn't mess with themes unless it **cannot** find the foreground color.

If I hypothetically generate my theme with an empty background or fontStyle string (or even if it isn't empty) SublimeLinter should leave the theme alone.

This has been bugging me for a while.  Something like this shouldn't cause SublimeLinter to duplicate a new theme:

```xml
		<dict>
			<key>name</key>
			<string>SublimeLinter Error</string>
			<key>scope</key>
			<string>sublimelinter.mark.error</string>
			<key>settings</key>
			<dict>
				<key>background</key>
				<string></string>
				<key>foreground</key>
				<string>#D02000</string>
			</dict>
		</dict>
```