### PR TITLE
Allow relative paths in settings

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1165,7 +1165,7 @@ class Linter(metaclass=LinterMeta):
             persist.printf('ERROR: {} cannot locate \'{}\''.format(self.name, which))
             return ''
 
-        cmd[0:1] = util.convert_type(path, [])
+        cmd[0:1] = util.convert_type(os.path.abspath(path), [])
         return self.insert_args(cmd)
 
     def context_sensitive_executable_path(self, cmd):


### PR DESCRIPTION
Creates an absolute path from the stringed path passed into linter.py