### PR TITLE
Add PythonImproved to list of python aliases

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -25,6 +25,7 @@
         "show_marks_in_minimap": true,
         "syntax_map": {
             "python django": "python",
+            "pythonimproved": "python",
             "magicpython": "python",
             "html 5": "html",
             "html (django)": "html",


### PR DESCRIPTION
This addresses [MattDMo/PythonImproved #36](https://github.com/MattDMo/PythonImproved/issues/36). Python Improved now has over 16k installations, so I figured it's about time to implement this :grinning: