### PR TITLE
Fixes issue !380, nested dictionaries are lost during linter settings tokenization

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -532,7 +532,7 @@ class Linter(metaclass=LinterMeta):
         """
         def recursive_replace_value(expressions, value):
             if isinstance(value, dict):
-                value = recursive_replace(expressions, value)
+                value = recursive_replace(expressions, value, nested=True)
             elif isinstance(value, list):
                 value = [recursive_replace_value(expressions, item) for item in value]
             elif isinstance(value, str):
@@ -544,14 +544,15 @@ class Linter(metaclass=LinterMeta):
 
             return value
 
-        def recursive_replace(expressions, mutable_input):
+        def recursive_replace(expressions, mutable_input, nested=False):
             for key, value in mutable_input.items():
                 mutable_input[key] = recursive_replace_value(expressions, value)
+            if nested:
+                return mutable_input
 
         # Expressions are evaluated in list order.
         expressions = []
         window = self.view.window()
-
         if window:
             view = window.active_view()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,10 @@ from mock import patch, MagicMock
 @fixture(scope='session', autouse=True)
 def mock_sublime(request):
     """Patch sys.modules to include a mock sublime module."""
-    module_patcher = patch.dict('sys.modules', {'sublime': MagicMock()})
+    sublime_mock = MagicMock()
+    sublime_mock.packages_path = MagicMock(return_value='mocked_sublime_packages_path')
+
+    module_patcher = patch.dict('sys.modules', {'sublime': sublime_mock})
     module_patcher.start()
 
     def fin():

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,0 +1,50 @@
+# coding=utf8
+#
+# test_util.py
+# Part of SublimeLinter3, a code checking framework for Sublime Text 3
+#
+# Written by Joshua Hagins
+#
+# Project: https://github.com/SublimeLinter/SublimeLinter3
+# License: MIT
+#
+
+"""This module tests functions in the lint.util module."""
+
+from pytest import fixture
+from mock import call, MagicMock, patch
+
+
+class TestLinter:
+
+    """ Class for testing Linter class """
+
+    def mock_view_window(self):
+        mwindow = MagicMock('window')
+        mview = MagicMock('view')
+        mview.window = MagicMock(return_value = mwindow)
+        mview.project_file_name = MagicMock(return_value = 'ppp')
+        return mview, mwindow
+
+    def test_replace_settings_tokens__no_replace(self):
+        """ Testing if can leave settings without changes if no tokens match """
+        import sublime
+        from lint import linter
+
+        mview, mwindow = self.mock_view_window()
+
+        m = linter.Linter(mview, mwindow)
+        settings = {'ignore_match': {'rb': ['.*unexpected.*end.*', 'some error']}}
+        m.replace_settings_tokens(settings)
+        assert settings == {'ignore_match': {'rb': ['.*unexpected.*end.*', 'some error']}}
+
+    def test_replace_settings_tokens__replace(self):
+        """ Testing if can leave settings without changes if token matches """
+        import sublime
+        from lint import linter
+        mview, mwindow = self.mock_view_window()
+
+        m = linter.Linter(mview, mwindow)
+        settings = {'ignore_match': {'rb': ['.*unexpected.*end.*', '${sublime} error']}}
+        m.replace_settings_tokens(settings)
+        assert settings == {'ignore_match': {'rb': ['.*unexpected.*end.*', 'mocked_sublime_packages_path error']}}


### PR DESCRIPTION
Hi

I've found some time to look into problem from SO: http://stackoverflow.com/questions/34057863/sublimelinter-ignore-match-not-working-when-extension-is-specified/34493594

I've found it's really simple, just for dict values `recursive_replace_value` function uses `recursive_replace` instead of `recursive_replace_value` and the first one does not return any value at all. This is why we have 'None' instead of dict with replaced arrays. So I've added parameter to control if the return should be invoked and voila ... tests are passing.

Sorry for this kind of crappy tests but I usually work with pure unittest and I do not know py.test so well. So these tests are rather basic but even with them I can prove that new version works (just compare same tests with branch and master linter.py to see)