### PR TITLE
On Windows try to use py.exe to find python executable

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -912,11 +912,10 @@ def find_windows_python(version):
 
         # Try to find python.exe using py.exe
         # Try the exact version first, then the major version
-        code = r'import sys;print(sys.executable)'
-        for version in (version, version.partition('.')[0]):
-            out = communicate(('py.exe', '-%s' % version), code)
-            if out:
-                path = out.splitlines()[0]
+        code = r'import sys;sys.stdout.write(sys.executable)'
+        for testversion in (version, version.partition('.')[0]):
+            path = communicate(('py.exe', '-%s' % testversion), code)
+            if path:
                 if ('python.exe' in path.lower()) and can_exec(path):
                     persist.debug('find_windows_python: <=', path)
                     return path
@@ -927,21 +926,22 @@ def find_windows_python(version):
         # passed in, strip any decimal points.
         stripped_version = version.replace('.', '')
         prefix = os.path.abspath(os.path.join(
-            os.environ.get("SYSTEMDRIVE", "\\"),
+            os.environ.get("SYSTEMDRIVE", ""),
+            os.sep,
             'Python'
         ))
         prefix_len = len(prefix)
         dirs = sorted(glob(prefix + '*'), reverse=True)
 
         # Try the exact version first, then the major version
-        for version in (stripped_version, stripped_version[0]):
+        for testversion in (stripped_version, stripped_version[0]):
             for python_dir in dirs:
                 path = os.path.join(python_dir, 'python.exe')
                 python_version = python_dir[prefix_len:]
                 persist.debug('find_windows_python: matching =>', path)
 
                 # Try the exact version first, then the major version
-                if python_version.startswith(version) and can_exec(path):
+                if python_version.startswith(testversion) and can_exec(path):
                     persist.debug('find_windows_python: <=', path)
                     return path
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -908,20 +908,30 @@ def find_windows_python(version):
     """Find the nearest version of python and return its path."""
 
     if version:
-        # On Windows, there may be no separately named python/python3 binaries,
-        # so it seems the only reliable way to check for a given version is to
-        # check the root drive for 'Python*' directories, and try to match the
+        from . import persist
+
+        # Try to find python.exe using py.exe
+        # Try the exact version first, then the major version
+        code = r'import sys;print(sys.executable)'
+        for version in (version, version.partition('.')[0]):
+            out = communicate(('py.exe', '-%s' % version), code)
+            if out:
+                path = out.splitlines()[0]
+                if ('python.exe' in path.lower()) and can_exec(path):
+                    persist.debug('find_windows_python: <=', path)
+                    return path
+
+        # Check the root drive for 'Python*' directories, and try to match the
         # version based on the directory names. The 'Python*' directories end
         # with the <major><minor> version number, so for matching with the version
         # passed in, strip any decimal points.
         stripped_version = version.replace('.', '')
         prefix = os.path.abspath(os.path.join(
-            os.environ.get("SYSTEMROOT", "\\")[:2],
+            os.environ.get("SYSTEMDRIVE", "\\"),
             'Python'
         ))
         prefix_len = len(prefix)
         dirs = sorted(glob(prefix + '*'), reverse=True)
-        from . import persist
 
         # Try the exact version first, then the major version
         for version in (stripped_version, stripped_version[0]):


### PR DESCRIPTION
Since Python 3.3 on Windows, a Python Launcher called py.exe is installed that call the correct interpreter depending of the argument or the shebang of the source file.
This Pull request try to call it to get the Python executable path.

Maybe it could be possible to always call py.exe (when available) with the correct argument instead of trying to find and call the correct Python executable. Need to look at it when I've some free times.
