### PR TITLE
Delete Side Bar.sublime-menu

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,9 +1,0 @@
-[
-    { "caption": "-"},
-    {
-        "caption": "New Package Control Message",
-        "command": "sublimelinter_new_package_control_message",
-        "args": {"paths": []}
-    },
-    { "caption": "-"}
-]


### PR DESCRIPTION
Removes irresponsible user of the sidebar menu

You are running this thingy every-time we right click any file folder in  the sidebar just to automate your need to add a new messages to SublimeLinter??

```
    def is_eligible_path(self, path):
        print('is_eligible_path')
        """
        Return True if path is an eligible directory.

        A directory is eligible if it has a messages subdirectory
        and has messages.json.

        """
        return (
            os.path.isdir(path) and
            os.path.isdir(os.path.join(path, 'messages')) and
            os.path.isfile(os.path.join(path, 'messages.json'))
        )
```

 I suggest to find another way to add the messages