### PR TITLE
find_python_script should use the login shell

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -947,7 +947,7 @@ def find_python_script(python_path, script):
     if sublime.platform() in ('osx', 'linux'):
         pyenv = which('pyenv')
         if pyenv:
-            out = run_shell_cmd((pyenv, 'which', script)).strip().decode()
+            out = run_shell_cmd((os.environ['SHELL'], '-l', '-c', 'echo ""; {} which {}'.format(pyenv, script))).strip().decode().split('\n')[-1]
             if os.path.isfile(out):
                 return out
         return which(script)

--- a/lint/util.py
+++ b/lint/util.py
@@ -947,7 +947,8 @@ def find_python_script(python_path, script):
     if sublime.platform() in ('osx', 'linux'):
         pyenv = which('pyenv')
         if pyenv:
-            out = run_shell_cmd((os.environ['SHELL'], '-l', '-c', 'echo ""; {} which {}'.format(pyenv, script))).strip().decode().split('\n')[-1]
+            out = run_shell_cmd((os.environ['SHELL'], '-l', '-c',
+                                 'echo ""; {} which {}'.format(pyenv, script))).strip().decode().split('\n')[-1]
             if os.path.isfile(out):
                 return out
         return which(script)


### PR DESCRIPTION
Noticed this issue at https://github.com/SublimeLinter/SublimeLinter-flake8/issues/12. SublimeLinter3 is calling out to pyenv but using /bin/sh instead of the login shell.