### PR TITLE
Don't terminate on package.json with no node_modules/deps.

### DIFF
--- a/lint/node_linter.py
+++ b/lint/node_linter.py
@@ -155,7 +155,9 @@ class NodeLinter(linter.Linter):
         name = 'package.json'
         manifest_path = path.normpath(path.join(cwd, name))
 
-        if path.isfile(manifest_path):
+        bin_path = path.join(cwd, 'node_modules/.bin/')
+
+        if path.isfile(manifest_path) and path.isdir(bin_path):
             return manifest_path
 
         parent = path.normpath(path.join(cwd, '../'))


### PR DESCRIPTION
Imagine a directory like this:

```
- package.json
- node_modules
  - .bin
    - eslint (we want linters to use this)
- app
  - package.json (empty, for managing absolute imports)
  - stuff.js
  - more
    - hello.js
- gulp.js
```

Only `gulp.js` would be linted by the proper local `node_module/.bin/eslint`. `stuff.js` and `hello.js` would revert to the "global" `/usr/local/bin/eslint` installation.

This change doesn't terminate on any `package.json` that don't have an accompanying `node_modules`.