### PR TITLE
Include error or warning code in message.

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1496,7 +1496,7 @@ class Linter(metaclass=LinterMeta):
 
                     self.highlight.range(line, pos, length=0, error_type=error_type, word_re=self.word_re)
 
-                self.error(line, col, message, error_type)
+                self.error(line, col, "%s %s" % (error or warning, message), error_type)
 
     def draw(self):
         """Draw the marks from the last lint."""


### PR DESCRIPTION
This adds error or warning codes in messages. For Python this results in for example:

```
... E226 missing whitespace around arithmetic operator ...
```

This allows one to use that code to ignore certain errors in the config.
