### PR TITLE
[Windows] Fix Python installations discovery for python@ type linters (issue #288)

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -915,10 +915,8 @@ def find_windows_python(version):
         # with the <major><minor> version number, so for matching with the version
         # passed in, strip any decimal points.
         stripped_version = version.replace('.', '')
-        prefix = os.path.abspath(os.path.join(
-            os.environ.get("SYSTEMROOT", "\\")[:2],
-            'Python'
-        ))
+        prefix = os.path.abspath(
+            os.path.join(os.environ.get('SYSTEMROOT', '\\')[:3], 'Python'))
         prefix_len = len(prefix)
         dirs = sorted(glob(prefix + '*'), reverse=True)
         from . import persist

--- a/lint/util.py
+++ b/lint/util.py
@@ -916,7 +916,7 @@ def find_windows_python(version):
         # passed in, strip any decimal points.
         stripped_version = version.replace('.', '')
         prefix = os.path.abspath(
-            os.path.join(os.environ.get('SYSTEMROOT', '\\')[:3], 'Python'))
+            os.path.join(os.environ.get('SYSTEMDRIVE', ''), '\\', 'Python'))
         prefix_len = len(prefix)
         dirs = sorted(glob(prefix + '*'), reverse=True)
         from . import persist


### PR DESCRIPTION
First two letters were taken from the SYSTEMROOT environment variable which is
incorrect as that would return 'C:' for 'C:\Windows'. Appending 'Python' to that
would end up with 'C:Python' which os.path.abspath would actually resolve to
'current working directory on C drive ' + Python which end up creating Path to
sublime directory.

Correctly take three characters so that we end up with C:\Python prefix.
