### PR TITLE
Fix reference before assignment error

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1599,7 +1599,7 @@ class Linter(metaclass=LinterMeta):
                     ' (disabled in settings)' if disabled else ''
                 )
             elif status is None:
-                status = 'WARNING: {} deactivated, cannot locate \'{}\''.format(cls.name, executable)
+                status = 'WARNING: {} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
 
             if status:
                 persist.printf(status)


### PR DESCRIPTION
'executable is not necessarily assigned at this point. Use cls.executable_path
'which is more appropriate anyway.
