### PR TITLE
Priority in Status Bar

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -401,9 +401,9 @@ class SublimeLinter(sublime_plugin.EventListener):
                 else:
                     status = '%i error%s' % (count, plural)
 
-                view.set_status('sublimelinter', status)
+                view.set_status('aasublimelinter', status)
             else:
-                view.erase_status('sublimelinter')
+                view.erase_status('aasublimelinter')
 
     def on_pre_save(self, view):
         """


### PR DESCRIPTION
Now if any plugin has `status_key` name, which in English alphabet is before `sublimelinter`, messages by these plugins are before of messages from SublimeLinter.

![Before](http://i.imgur.com/l9mXOy8.png)

But I want, when SublimeLinter messages has high priority. And I think that many users would like high priority for SublimeLinter, otherwise messages of other plugins are make SublimeLinter messages not be visible. My pull-request are make high priority for SublimeLinter messages.

![After](http://i.imgur.com/JNXZo5c.png)

Thanks.
