### PR TITLE
Prevent IndexError if strip_quotes returns empty string

### DIFF
--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -327,6 +327,9 @@ class Highlight:
         text = self.code[start:end]
         near = self.strip_quotes(near)
 
+        if near == '':
+            return 0
+
         # Add \b fences around the text if it begins/ends with a word character
         fence = ['', '']
 


### PR DESCRIPTION
If `strip_quotes` returns an empty string this

    for i, pos in enumerate((0, -1)):
        if near[pos].isalnum() or near[pos] == '_':

will fail with an IndexError:

    Traceback (most recent call last):
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/lint/queue.py", line 65, in loop
        self.lint(view_id, timestamp)
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/lint/queue.py", line 111, in lint
        self.callback(view_id, timestamp)
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 119, in lint
        Linter.lint_view(view, filename, code, hit_time, callback)
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/lint/linter.py", line 929, in lint_view
        linter.lint(hit_time)
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/lint/linter.py", line 1487, in lint
        col = self.highlight.near(line, near, error_type=error_type, word_re=self.word_re)
      File "/home/silvasur/.config/sublime-text-3/Packages/SublimeLinter/lint/highlight.py", line 334, in near
        if near[pos].isalnum() or near[pos] == '_':
    IndexError: string index out of range

This commit fixes this