### PR TITLE
Fix tooltip immediately closing and replacing other popups

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -403,8 +403,6 @@ class SublimeLinter(sublime_plugin.EventListener):
                         self.open_tooltip(lineno, line_errors)
                 else:
                     status = '%i error%s' % (count, plural)
-                    if persist.settings.get('tooltips'):
-                        self.close_tooltip()
 
                 view.set_status('sublimelinter', status)
             else:
@@ -437,7 +435,8 @@ class SublimeLinter(sublime_plugin.EventListener):
         """
         Show a tooltip containing all linting errors on a given line.
 
-        If no tooltip template can be created, does nothing.
+        Does nothing if no tooltip template can be created, or if another popup
+        is already displayed.
 
         """
         template = self.get_template()
@@ -446,6 +445,11 @@ class SublimeLinter(sublime_plugin.EventListener):
             return
 
         active_view = self.get_active_view()
+
+        # Leave any existing popup open without replacing it
+        if active_view.is_popup_visible():
+            return
+
         tooltip_content = template.substitute(line=line,
                                               message='<br />'.join(errors),
                                               font_size=persist.settings.get('tooltip_fontsize'))
@@ -453,11 +457,6 @@ class SublimeLinter(sublime_plugin.EventListener):
                                flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
                                location=-1,
                                max_width=600)
-
-    def close_tooltip(self):
-        """Close the currently active tooltip, if there is one."""
-        active_view = self.get_active_view()
-        active_view.hide_popup()
 
     def on_pre_save(self, view):
         """


### PR DESCRIPTION
This change fixes #565. 

Bug Summary: When tooltips are enabled, any other popups will be immediately closed or replaced by SublimeLinter tooltips.

Conditions under which the bug occurs:
- [Environment] 
  - OS: Linux Mint 18.1 (probably most other OSs as well, implied by issue thread)
  - Enable tooltips option in preferences
  - Use the ESLint plugin (or any other plugin with error messages)
- [Test] When triggering a non-linter popup via keyboard:
  - Press <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>ALT</kbd> + <kbd>P</kbd> to reveal scope names in a popup
- [Test] When triggering a non-linter popup via hovering (using GitGutter as an example):
  - Hover over the gutter on an edited line to reveal its Git diff in a popup
- [Error Results] In both cases, the corresponding popup is closed
  1. When caret is on a line without lint errors
     - Error behavior: Popup flashes for a split second, then closes
  2. When caret is on a line with lint errors
     - Error behavior: Popup flashes for a split second, then is replaced by linter tooltip

The expected behavior for all cases is for the original popup to remain open. 

The tooltip display is triggered by the `on_selector_modified` event. In both cases, the `on_selection_modified` event fires immediately after the popup appears, which then tries to replace it with the linter tooltip. This PR fixes that by:
- Not closing popups when `on_selection_modified` is fired
  - Fixes no. 1
  - From my testing, any linter tooltips will still close when mouse is moved away, the caret moves, or if the view changes focus
- Not opening tooltips when a popup is already on-screen
  - Fixes no. 2

In the future, it may benefit to modify the tooltip to 1) bind to a less-frequently triggered event such as `on_hover`, and 2) display the tooltip for each highlighted section, not for a whole line. 