### PR TITLE
Fix tooltip appearing after every re-highlight and view focus

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -172,7 +172,7 @@ class SublimeLinter(sublime_plugin.EventListener):
                         window_views[wid] = other_view
 
         for view in window_views.values():
-            self.on_selection_modified_async(view)
+            self.display_errors(view)
 
     def hit(self, view):
         """Record an activity that could trigger a lint and enqueue a desire to lint."""
@@ -286,7 +286,7 @@ class SublimeLinter(sublime_plugin.EventListener):
             if persist.settings.get('lint_mode', 'background') in ('background', 'load/save'):
                 self.hit(view)
 
-        self.on_selection_modified_async(view)
+        self.display_errors(view)
 
     def on_open_settings(self, view):
         """
@@ -354,6 +354,15 @@ class SublimeLinter(sublime_plugin.EventListener):
 
     def on_selection_modified_async(self, view):
         """Called when the selection changes (cursor moves or text selected)."""
+        self.display_errors(view, tooltip=True)
+
+    def display_errors(self, view, tooltip=False):
+        """
+        Display lint errors in the view status.
+
+        If tooltip is set to True, also display lint errors in a tooltip
+        at the caret's position.
+        """
 
         if self.is_scratch(view):
             return
@@ -399,7 +408,8 @@ class SublimeLinter(sublime_plugin.EventListener):
                         status = 'Error: '
 
                     status += '; '.join(line_errors)
-                    if persist.settings.get('tooltips'):
+
+                    if persist.settings.get('tooltips') and tooltip:
                         self.open_tooltip(lineno, line_errors)
                 else:
                     status = '%i error%s' % (count, plural)


### PR DESCRIPTION
Bug: 
1. Tooltip pops up after every lint highlight update
2. Tooltip pops up on view focus

Expected:
- Linter tooltip should not appear on re-highlight or on view focus

To reproduce:
1. Highlight triggers tooltip
   - Enter code that will fail linter
   - Switch to another window before re-highlighting is finished
   - After a few seconds, linter tooltip will appear despite the original view not being in focus
2. View focus triggers tooltip
   - Select text with lint errors
   - Switch to another window and switch back
   - Tooltip appears automatically

This bug was caused by manually triggering `on_selector_modified` in the `highlight` and `on_activated` methods. I extracted the contents of the original `on_selector_modified` into a new method named `display_errors` with an optional flag `tooltip`. Within `on_selector_modified`, it calls the method with `tooltip=True`, while `highlight` and `on_activated` call it with `tooltip` defaulting to `False`.

Feedback is welcome! Currently the codebase seems to fail the lint test, [presumably due to the pydocstyle v2.0.0 update](https://github.com/SublimeLinter/SublimeLinter3/pull/577#issuecomment-298201887), so perhaps we should test with `pydocstyle . --add-ignore=D202,D401` for now. Let me know what you think.