### PR TITLE
Fix version of pydocstyle for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
 install:
   - "pip install flake8"
-  - "pip install pydocstyle"
+  - "pip install pydocstyle==1.1.1"
   - "pip install pytest-cov"
   - "pip install codecov"
 


### PR DESCRIPTION
Fix CI build by fixing version `pydocstyle` to 1.1.1

Required to make pass new PRs like #577 or #581 