### PR TITLE
[Fix #586] Allow the linter to configure itself.

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1540,6 +1540,8 @@ class Linter(metaclass=LinterMeta):
         can = False
         syntax = syntax.lower()
 
+        cls.reinitialize()  # Allow the linter to configure itself.
+
         if cls.syntax:
             if isinstance(cls.syntax, (tuple, list)):
                 can = syntax in cls.syntax


### PR DESCRIPTION
By running the supplied linter initialiser in `can_lint`, the linter can adjust its `executable_path`. This allows the executable path to be configured in the linter user settings, as in https://github.com/veelo/SublimeLinter-contrib-epcomp/blob/master/linter.py#L49.