### PR TITLE
move executable variable initialization to stop missing variable exceptions

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1539,6 +1539,7 @@ class Linter(metaclass=LinterMeta):
 
         can = False
         syntax = syntax.lower()
+        executable = ''
 
         if cls.syntax:
             if isinstance(cls.syntax, (tuple, list)):
@@ -1552,8 +1553,6 @@ class Linter(metaclass=LinterMeta):
 
         if can:
             if cls.executable_path is None:
-                executable = ''
-
                 if not callable(cls.cmd):
                     if isinstance(cls.cmd, (tuple, list)):
                         executable = (cls.cmd or [''])[0]


### PR DESCRIPTION
I've seen at least two of these issues already (https://github.com/SublimeLinter/SublimeLinter-jshint/issues/33 and https://github.com/SublimeLinter/SublimeLinter3/issues/88) and they have been closed, but wasn't sure why, as I had the same problem this morning.

This pr attempts to fix the problem where the `executable` variable is not defined, which seems to happen when can is set to `False`, therefore `executable` is never defined.