### PR TITLE
linter: Print debugging message if match fails

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1776,6 +1776,7 @@ class Linter(metaclass=LinterMeta):
 
             return match, line, col, error, warning, message, near
         else:
+            persist.debug('No match for {}'.format(self.regex))
             return match, None, None, None, None, '', None
 
     def run(self, cmd, code):


### PR DESCRIPTION
This commit makes split_match print a debugging message if the match completely fails, meaning that no groups have been captured.

I ran into this problem while writing a linter plugin for SublimeLinter3 - I had a *very* trivial (and hard to pick out) mistake in my regular expression, and the lack of a debugging message telling me about a missing match made it difficult to pinpoint the failure.