### PR TITLE
variable 'executable' referenced before assignment

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1551,9 +1551,8 @@ class Linter(metaclass=LinterMeta):
                 can = cls.syntax.match(syntax) is not None
 
         if can:
+            executable = ''
             if cls.executable_path is None:
-                executable = ''
-
                 if not callable(cls.cmd):
                     if isinstance(cls.cmd, (tuple, list)):
                         executable = (cls.cmd or [''])[0]


### PR DESCRIPTION
` UnboundLocalError: local variable 'executable' referenced before assignment `
error occur in L:1601
when `cls.executable_path is not None` and `status is None`