### PR TITLE
replace Default/User settings with split view

### DIFF
--- a/Main.sublime-menu.template
+++ b/Main.sublime-menu.template
@@ -30,55 +30,11 @@
 								}
 							},
 							{
-								"caption": "-"
-							},
-							{
-								"caption": "Key Bindings – Default",
-								"command": "open_file", "args":
+								"caption": "Key Bindings",
+								"command": "edit_settings", "args":
 								{
-									"file": "${packages}/SublimeLinter/Default (OSX).sublime-keymap",
-									"platform": "OSX"
-								}
-							},
-							{
-								"caption": "Key Bindings – User",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/User/Default (OSX).sublime-keymap",
-									"platform": "OSX"
-								}
-							},
-							{
-								"caption": "Key Bindings – Default",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/SublimeLinter/Default (Linux).sublime-keymap",
-									"platform": "Linux"
-								}
-							},
-							{
-								"caption": "Key Bindings – User",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/User/Default (Linux).sublime-keymap",
-									"platform": "Linux"
-								}
-							},
-							{
-								"caption": "Key Bindings – Default",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/SublimeLinter/Default (Windows).sublime-keymap",
-									"platform": "Windows"
-								}
-							},
-							{
-								"caption": "Key Bindings – User",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/User/Default (Windows).sublime-keymap",
-									"platform": "Windows"
-								}
+									"base_file": "${packages}/SublimeLinter/Default ($platform).sublime-keymap",
+									"default": "${packages}/User/Default ($platform).sublime-keymap"								}
 							}
 						]
 					}

--- a/Main.sublime-menu.template
+++ b/Main.sublime-menu.template
@@ -33,52 +33,52 @@
 								"caption": "-"
 							},
 							{
-							    "caption": "Key Bindings – Default",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/SublimeLinter/Default (OSX).sublime-keymap",
-							        "platform": "OSX"
-							    }
+								"caption": "Key Bindings – Default",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/SublimeLinter/Default (OSX).sublime-keymap",
+									"platform": "OSX"
+								}
 							},
 							{
-							    "caption": "Key Bindings – User",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/User/Default (OSX).sublime-keymap",
-							        "platform": "OSX"
-							    }
+								"caption": "Key Bindings – User",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/User/Default (OSX).sublime-keymap",
+									"platform": "OSX"
+								}
 							},
 							{
-							    "caption": "Key Bindings – Default",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/SublimeLinter/Default (Linux).sublime-keymap",
-							        "platform": "Linux"
-							    }
+								"caption": "Key Bindings – Default",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/SublimeLinter/Default (Linux).sublime-keymap",
+									"platform": "Linux"
+								}
 							},
 							{
-							    "caption": "Key Bindings – User",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/User/Default (Linux).sublime-keymap",
-							        "platform": "Linux"
-							    }
+								"caption": "Key Bindings – User",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/User/Default (Linux).sublime-keymap",
+									"platform": "Linux"
+								}
 							},
 							{
-							    "caption": "Key Bindings – Default",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/SublimeLinter/Default (Windows).sublime-keymap",
-							        "platform": "Windows"
-							    }
+								"caption": "Key Bindings – Default",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/SublimeLinter/Default (Windows).sublime-keymap",
+									"platform": "Windows"
+								}
 							},
 							{
-							    "caption": "Key Bindings – User",
-							    "command": "open_file", "args":
-							    {
-							        "file": "${packages}/User/Default (Windows).sublime-keymap",
-							        "platform": "Windows"
-							    }
+								"caption": "Key Bindings – User",
+								"command": "open_file", "args":
+								{
+									"file": "${packages}/User/Default (Windows).sublime-keymap",
+									"platform": "Windows"
+								}
 							}
 						]
 					}

--- a/Main.sublime-menu.template
+++ b/Main.sublime-menu.template
@@ -22,17 +22,11 @@
 						"children":
 						[
 							{
-								"caption": "Settings – Default",
-								"command": "open_file", "args":
+								"caption": "Settings",
+								"command": "edit_settings", "args":
 								{
-									"file": "${packages}/SublimeLinter/SublimeLinter.sublime-settings"
-								}
-							},
-							{
-								"caption": "Settings – User",
-								"command": "open_file", "args":
-								{
-									"file": "${packages}/User/SublimeLinter.sublime-settings"
+									"base_file": "${packages}/SublimeLinter/SublimeLinter.sublime-settings",
+									"default": "${packages}/User/SublimeLinter.sublime-settings"
 								}
 							},
 							{


### PR DESCRIPTION
Recent builds of Sublime Text 3 introduced a new split view mode for editing settings. From a single menu entry Default and User settings are displayed side by side, which makes it so much more easy to edit.