### PR TITLE
enable jruby support

### DIFF
--- a/lint/ruby_linter.py
+++ b/lint/ruby_linter.py
@@ -90,7 +90,7 @@ class RubyLinter(linter.Linter):
 
         if not ruby:
             ruby = util.which('ruby')
-        
+
         if not ruby:
             ruby = util.which('jruby')
 

--- a/lint/ruby_linter.py
+++ b/lint/ruby_linter.py
@@ -90,6 +90,9 @@ class RubyLinter(linter.Linter):
 
         if not ruby:
             ruby = util.which('ruby')
+        
+        if not ruby:
+            ruby = util.which('jruby')
 
         if not rbenv and not ruby:
             persist.printf(


### PR DESCRIPTION
The ruby_linter does not work on Windows with jruby installations.
It deactivates all ruby related plugins (e.g. linter-rubocop) because it can not detect native jruby installations.

This PR fixes this issues and enables usage of SublimeLinter with natively installed jruby