### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'views'

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -347,6 +347,8 @@ class SublimeLinter(sublime_plugin.EventListener):
 
         """
         active_view = view.window().active_view()
+        if active_view is None:
+            return
 
         for view in view.window().views():
             if view == active_view:


### PR DESCRIPTION
    Traceback (most recent call last):
    File "/home/code/sublime_text_3/sublime_plugin.py", line 513, in on_selection_modified_async
        callback.on_selection_modified_async(v)
    File "/home/code/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 361, in on_selection_modified_async
        view = self.get_focused_view_id(view)
    File "/home/code/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 351, in get_focused_view_id
        for view in view.window().views():
    AttributeError: 'NoneType' object has no attribute 'views'