### PR TITLE
Feature: add verbose log in debug for script version match fail

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1724,6 +1724,10 @@ class Linter(metaclass=LinterMeta):
             return version
         else:
             persist.printf('WARNING: no {} version could be extracted from:\n{}'.format(cls.name, version))
+            persist.debug('          using cmd: {}, env: {}'.format(
+                cmd,
+                util.create_environment()
+            ))
             return None
 
     @staticmethod


### PR DESCRIPTION
I believe this would have helped many users to determine why certain linters fail to get an executable's version.

It certainly helped me while debugging my own and assisting others in SublimeLinter/SublimeLinter-flake8#51 and SublimeLinter/SublimeLinter-flake8#56