### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'active_view'

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -479,12 +479,12 @@ class SublimeLinter(sublime_plugin.EventListener):
         copy the current settings first so we can compare post-save.
 
         """
-        if view.window().active_view() == view and self.is_settings_file(view):
+        window = view.window()
+        if window and window.active_view() == view and self.is_settings_file(view):
             persist.settings.copy()
 
     def on_post_save_async(self, view):
         """Ran after view is saved."""
-
         if self.is_scratch(view):
             return
 


### PR DESCRIPTION
Error:

```
Traceback (most recent call last):
File "/home/code/sublime_text_3/sublime_plugin.py", line 465, in on_pre_save_async
    callback.on_pre_save_async(v)
File "/home/code/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 482, in on_pre_save_async
    if view.window().active_view() == view and self.is_settings_file(view):
AttributeError: 'NoneType' object has no attribute 'active_view'
```