### PR TITLE
Use current shell path if use_current_shell_path is true

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -6,6 +6,7 @@
         "gutter_theme": "Packages/SublimeLinter/gutter-themes/Default/Default.gutter-theme",
         "gutter_theme_excludes": [],
         "lint_mode": "background",
+        "use_current_shell_path": false,
         "mark_style": "outline",
         "no_column_highlights_line": false,
         "passive_warnings": false,

--- a/lint/util.py
+++ b/lint/util.py
@@ -526,6 +526,11 @@ def get_shell_path(env):
 
     """
 
+    from . import persist
+
+    if persist.settings.get('use_current_shell_path') is True:
+        return env['PATH']
+
     if 'SHELL' in env:
         shell_path = env['SHELL']
         shell = os.path.basename(shell_path)


### PR DESCRIPTION
Right now, I'm working on some Ruby/Rails projects using an in-house developed tool to aid in development environment setup/creation.

Basically, it installs the right version of Ruby, the needed gems and finally it add the project ruby to the PATH before the system binaries dir.

My environment is as follows:

- ruby 2.4.2 in /usr/local/bin with rubocop installed and my default PATH:

```bash
» env | grep PATH
PATH=/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/usr/local/heroku/bin:/Users/douglas/work/golang/bin:/Users/douglas/.composer/vendor/bin:/Users/douglas/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/douglas/Library/Android/sdk/platform-tools:/Users/douglas/Library/Android/sdk/tools/bin:/usr/local/opt/fzf/bin
```
- ruby 2.3.5 when I ```cd ~/work/project```:

```bash
» env | grep PATH
PATH=/Users/douglas/.gem/ruby/2.3.5/bin:/opt/rubies/2.3.5/lib/ruby/gems/2.3.0/bin:/opt/rubies/2.3.5/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/usr/local/heroku/bin:/Users/douglas/work/golang/bin:/Users/douglas/.composer/vendor/bin:/Users/douglas/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/douglas/Library/Android/sdk/platform-tools:/Users/douglas/Library/Android/sdk/tools/bin:/usr/local/opt/fzf/bin
```

With the current implementation of ```get_shell_path```, when I _cd_  to the ```~/work/project``` directory and open SublimeText using ```» subl .```, I get the first shell PATH (my default shell path) instead of the current session PATH, so, it will not find the rubocop binary installed for the project.

With this PR, it will be possible to tell SublimeLinter to just return the PATH defined in the current session, allowing _SublimeLinter-rubocop_ to find the right executable. 