### PR TITLE
Fix issue with unassigned variable

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1590,9 +1590,9 @@ class Linter(metaclass=LinterMeta):
                 can = cls.syntax.match(syntax) is not None
 
         if can:
-            if cls.executable_path is None:
-                executable = ''
+            executable = ''
 
+            if cls.executable_path is None:
                 if not callable(cls.cmd):
                     if isinstance(cls.cmd, (tuple, list)):
                         executable = (cls.cmd or [''])[0]


### PR DESCRIPTION
I was getting the following error, and it was preventing some files from being linted.
```
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 538, in on_activated_async
    callback.on_activated_async(v)
  File "/home/emma/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 280, in on_activated_async
    self.check_syntax(view)
  File "/home/emma/.config/sublime-text-3/Packages/SublimeLinter/sublimelinter.py", line 207, in check_syntax
    Linter.assign(view, reset=True)
  File "/home/emma/.config/sublime-text-3/Packages/SublimeLinter/lint/linter.py", line 773, in assign
    if not linter_class.disabled and linter_class.can_lint(syntax):
  File "./python3.3/functools.py", line 251, in wrapper
  File "/home/emma/.config/sublime-text-3/Packages/SublimeLinter/lint/linter.py", line 1641, in can_lint
    status = 'WARNING: {} deactivated, cannot locate \'{}\''.format(cls.name, executable)
UnboundLocalError: local variable 'executable' referenced before assignment
```
Assigning `executable` before the if seems to fix things.