### PR TITLE
Specify defaults for all settings

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -1,10 +1,10 @@
 {
     // Optionally disable all linters
-    // @disable: true
+    "@disable": false,
 
     // Optionally specify a python version
     // http://www.sublimelinter.com/en/latest/meta_settings.html#python-meta-setting
-    // @python: 3
+    "@python": null,
 
     "debug": false,
 
@@ -50,6 +50,7 @@
     //         "select": ""
     //     }
     // }
+    "linters": {},
 
     // Determines what happens when a linter reports an error without column.
     // By default, a mark is put in the gutter but no text is highlighted.


### PR DESCRIPTION
Ensures better interop with PackageDev and its setting name linting (and the edit link in side-by-side settings).

No ide about the default of `@python`, so I just made it `null`. Hope that doesn't break anything.