### PR TITLE
Print source pattern of failed regex match

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1661,7 +1661,7 @@ class Linter(metaclass=LinterMeta):
 
             return match, line, col, error, warning, message, near
         else:
-            persist.debug('No match for {}'.format(self.regex))
+            persist.debug('No match for regex: {}'.format(self.regex.pattern))
             return match, None, None, None, None, '', None
 
     def run(self, cmd, code):


### PR DESCRIPTION
The string representation of a compiled regex object isn't that exciting.

```py
>>> import re
>>> re.compile("abc")
<_sre.SRE_Pattern object at 0x7f694c33f630>
>>> _.pattern
'abc'
```