### PR TITLE
Fix: Panel flickers when typing *anywhere*

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,3 +1,4 @@
+import sublime
 import sublime_plugin
 
 from .lint import persist
@@ -68,3 +69,8 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
             cmd = "hide_panel"
 
         self.window.run_command(cmd, {"panel": "output." + name or ""})
+
+
+class SublimeLinterReplaceAllCommand(sublime_plugin.TextCommand):
+    def run(self, edit, characters):
+        self.view.replace(edit, sublime.Region(0, self.view.size()), characters)

--- a/panel/panel.py
+++ b/panel/panel.py
@@ -22,11 +22,11 @@ OUTPUT_PANEL_SETTINGS = {
 
 
 def update_panel(view, text=""):
-    view.set_read_only(False)
-    view.run_command('select_all')
-    view.run_command('left_delete')
-    view.run_command('append', {'characters': text})
-    view.set_read_only(True)
+    try:
+        view.set_read_only(False)
+        view.run_command('sublime_linter_replace_all', {'characters': text})
+    finally:
+        view.set_read_only(True)
 
 
 def dedupe_views(errors):


### PR DESCRIPTION
This commit introduces the "sublime_linter_replace_all" command to replace the whole content of a view with only one TextCommand to avoid repainting the view several times while updateing its whole content.