### PR TITLE
Update panel in a single TextCommand

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,3 +1,4 @@
+import sublime
 import sublime_plugin
 
 from .lint import persist
@@ -68,3 +69,25 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
             cmd = "hide_panel"
 
         self.window.run_command(cmd, {"panel": "output." + name or ""})
+
+
+class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
+    def run(self, edit, text=""):
+        """Replace a view's text entirely and attempt to restore previous selection."""
+        sel = self.view.sel()
+        # Doesn't make sense to consider multiple selections
+        selected_region = sel[0] if sel else None
+        selected_text = self.view.substr(selected_region) if sel else None
+
+        self.view.set_read_only(False)
+        self.view.replace(edit, sublime.Region(0, self.view.size()), text)
+        self.view.set_read_only(True)
+
+        sel.clear()
+        if selected_text:
+            new_selected_region = self.view.find(selected_text, 0, flags=sublime.LITERAL)
+            if new_selected_region:
+                sel.add(new_selected_region)
+                return
+
+        sel.add(0)

--- a/commands.py
+++ b/commands.py
@@ -72,7 +72,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
-    def run(self, edit, text=""):
+    def run(self, edit, text="", clear_sel=False):
         """Replace a view's text entirely and attempt to restore previous selection."""
         sel = self.view.sel()
         # Doesn't make sense to consider multiple selections
@@ -84,7 +84,7 @@ class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
         self.view.set_read_only(True)
 
         sel.clear()
-        if selected_text:
+        if selected_text and not clear_sel:
             new_selected_region = self.view.find(selected_text, 0, flags=sublime.LITERAL)
             if new_selected_region:
                 sel.add(new_selected_region)

--- a/panel/panel.py
+++ b/panel/panel.py
@@ -112,6 +112,7 @@ def fill_panel(window, types=None, codes=None, linter=None, update=False):
 
     errors = filter_errors(window, errors)
     errors = dedupe_views(errors)
+
     path_dict, base_dir = create_path_dict(errors)
     assert window, "missing window!"
 
@@ -160,4 +161,8 @@ def fill_panel(window, types=None, codes=None, linter=None, update=False):
 
         to_render.append("\n")  # empty lines between views
 
-    panel.run_command('sublime_linter_update_panel', {'text': "\n".join(to_render).strip()})
+    if to_render:
+        panel.run_command('sublime_linter_update_panel', {'text': "\n".join(to_render).strip()})
+    else:
+        panel.run_command('sublime_linter_update_panel',
+                          {'text': "No lint errors.", 'clear_sel': True})

--- a/panel/panel.py
+++ b/panel/panel.py
@@ -21,14 +21,6 @@ OUTPUT_PANEL_SETTINGS = {
 }
 
 
-def update_panel(view, text=""):
-    view.set_read_only(False)
-    view.run_command('select_all')
-    view.run_command('left_delete')
-    view.run_command('append', {'characters': text})
-    view.set_read_only(True)
-
-
 def dedupe_views(errors):
     if len(errors) == 1:
         return errors
@@ -168,4 +160,4 @@ def fill_panel(window, types=None, codes=None, linter=None, update=False):
 
         to_render.append("\n")  # empty lines between views
 
-    update_panel(panel, text="\n".join(to_render).strip())
+    panel.run_command('sublime_linter_update_panel', {'text': "\n".join(to_render).strip()})


### PR DESCRIPTION
Prevents panel from flickering due to multiple commands updatating its
contents (fixes #700).

Also try to restore the previous selection to allow the user to continue
browsing errors exactly were they left off. Reset to the beginning
otherwise.