### PR TITLE
Replace python linter

### DIFF
--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -10,6 +10,7 @@ from . import (
 
 from .linter import Linter
 from .base_linter.python_linter import PythonLinter
+from .base_linter.new_python_linter import NewPythonLinter
 from .base_linter.ruby_linter import RubyLinter
 from .base_linter.node_linter import NodeLinter
 from .base_linter.composer_linter import ComposerLinter

--- a/lint/base_linter/new_python_linter.py
+++ b/lint/base_linter/new_python_linter.py
@@ -1,0 +1,294 @@
+"""This module exports the NewPythonLinter subclass of Linter."""
+
+from functools import lru_cache
+import os
+import subprocess
+
+import sublime
+from .. import linter, persist, util
+
+
+class NewPythonLinter(linter.Linter):
+    """New Python Linter [WIP]."""
+
+    comment_re = r'\s*#'
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def can_lint(cls, syntax):
+        """Determine optimistically if the linter can handle the provided syntax."""
+        can = False
+        syntax = syntax.lower()
+
+        if cls.syntax:
+            if isinstance(cls.syntax, (tuple, list)):
+                can = syntax in cls.syntax
+            elif cls.syntax == '*':
+                can = True
+            elif isinstance(cls.syntax, str):
+                can = syntax == cls.syntax
+            else:
+                can = cls.syntax.match(syntax) is not None
+
+        return can
+
+    def context_sensitive_executable_path(self, cmd):
+        """Try to find an executable for a given cmd."""
+        settings = self.get_view_settings()
+
+        # If the user explicitly set an executable, it takes precedence.
+        # We expand environment variables. E.g. a user could have a project
+        # structure where a virtual environment is always located within
+        # the project structure. She could then simply specify
+        # `${project_path}/venv/bin/flake8`. Note that setting `@python`
+        # to a path will have a similar effect.
+        executable = settings.get('executable', '')
+        if executable:
+            executable = expand_variables(executable)
+
+            persist.debug(
+                "{}: wanted executable is '{}'".format(self.name, executable)
+            )
+
+            if util.can_exec(executable):
+                return True, executable
+
+            persist.printf(
+                "ERROR: {} deactivated, cannot locate '{}' "
+                .format(self.name, executable)
+            )
+            # no fallback, the user specified something, so we err
+            return True, None
+
+        # `@python` can be number or a string. If it is a string it should
+        # point to a python environment, NOT a python binary.
+        # We expand environment variables. E.g. a user could have a project
+        # structure where virtual envs are located always like such
+        # `some/where/venvs/${project_base_name}` or she has the venv
+        # contained in the project dir `${project_path}/venv`. She then
+        # could edit the global settings once and can be sure that always the
+        # right linter installed in the virtual environment gets executed.
+        python = settings.get('@python', None)
+        if isinstance(python, str):
+            python = expand_variables(python)
+
+        persist.debug(
+            "{}: wanted @python is '{}'".format(self.name, python)
+        )
+
+        cmd_name = cmd[0] if isinstance(cmd, (list, tuple)) else cmd
+
+        if python:
+            if isinstance(python, str):
+                executable = find_script_by_python_env(
+                    python, cmd_name
+                )
+                if not executable:
+                    persist.printf(
+                        "WARNING: {} deactivated, cannot locate '{}' "
+                        "for given @python '{}'"
+                        .format(self.name, cmd_name, python)
+                    )
+                    # Do not fallback, user specified something we didn't find
+                    return True, None
+
+                return True, executable
+
+            else:
+                executable = find_script_by_python_version(
+                    cmd_name, str(python)
+                )
+
+                # If we didn't find anything useful, use the legacy
+                # code from SublimeLinter for resolving that version.
+                if executable is None:
+                    persist.debug(
+                        "{}: Still trying to resolve {}, now trying "
+                        "SublimeLinter's legacy code."
+                        .format(self.name, python)
+                    )
+                    _, executable, *_ = util.find_python(
+                        str(python), cmd_name
+                    )
+
+                if executable is None:
+                    persist.printf(
+                        "WARNING: {} deactivated, cannot locate '{}' "
+                        "for given @python '{}'"
+                        .format(self.name, cmd_name, python)
+                    )
+                    return True, None
+
+                persist.debug(
+                    "{}: Using {} for given @python '{}'"
+                    .format(self.name, executable, python)
+                )
+                return True, executable
+
+        # If we're here the user didn't specify anything. This is the default
+        # experience. So we kick in some 'magic'
+        chdir = self.get_chdir(settings)
+        executable = ask_pipenv(cmd[0], chdir)
+        if executable:
+            persist.debug(
+                "{}: Using {} according to 'pipenv'"
+                .format(self.name, executable)
+            )
+            return True, executable
+
+        # Should we try a `pyenv which` as well? Problem: I don't have it,
+        # it's MacOS only.
+
+        persist.debug(
+            "{}: trying to use globally installed {}"
+            .format(self.name, cmd_name)
+        )
+        # fallback, similiar to a which(cmd)
+        executable = find_executable(cmd_name)
+        if executable is None:
+            persist.printf(
+                "WARNING: cannot locate '{}'. Fill in the '@python' or "
+                "'executable' setting."
+                .format(self.name)
+            )
+        return True, executable
+
+
+def _find_executables(executable):
+    env = util.create_environment()
+
+    for base in env.get('PATH', '').split(os.pathsep):
+        path = os.path.join(os.path.expanduser(base), executable)
+
+        # On Windows, if path does not have an extension, try .exe, .cmd, .bat
+        if sublime.platform() == 'windows' and not os.path.splitext(path)[1]:
+            for extension in ('.exe', '.cmd', '.bat'):
+                path_ext = path + extension
+
+                if util.can_exec(path_ext):
+                    yield path_ext
+        elif util.can_exec(path):
+            yield path
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_executable(executable):
+    """Return the full path to an executable searching PATH."""
+    for path in _find_executables(executable):
+        return path
+
+    return None
+
+
+def find_python_version(version):  # type: Str
+    """Return python binaries on PATH matching a specific version."""
+    requested_version = util.extract_major_minor_version(version)
+    for python in _find_executables('python'):
+        python_version = util.get_python_version(python)
+        if util.version_fulfills_request(python_version, requested_version):
+            yield python
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_script_by_python_version(script_name, version):
+    """Return full path to a script, given just a python version."""
+    # They can be multiple matching pythons. We try to find a python with
+    # its complete environment, not just a symbolic link or so.
+    for python in find_python_version(version):
+        python_env = os.path.dirname(python)
+        script_path = find_script_by_python_env(python_env, script_name)
+        if script_path:
+            return script_path
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_script_by_python_env(python_env_path, script):
+    """Return full path to a script, given a python environment base dir."""
+    posix = sublime.platform() in ('osx', 'linux')
+
+    if posix:
+        full_path = os.path.join(python_env_path, 'bin', script)
+    else:
+        full_path = os.path.join(python_env_path, 'Scripts', script + '.exe')
+
+    persist.printf("trying {}".format(full_path))
+    if os.path.exists(full_path):
+        return full_path
+
+    return None
+
+
+def expand_variables(string):
+    """Expand typical sublime variables in the given string."""
+    window = sublime.active_window()
+    env = window.extract_variables()
+    return sublime.expand_variables(string, env)
+
+
+def get_project_path():
+    """Return the project_path using Sublime's window.project_data() API."""
+    window = sublime.active_window()
+    # window.project_data() is a relative new API.
+    # I don't know what we can expect from 'folders' here. Can we just take
+    # the first one, if any, and be happy?
+    project_data = window.project_data() or {}
+    folders = project_data.get('folders', [])
+    if folders:
+        return folders[0]['path']  # ?
+
+
+def ask_pipenv(linter_name, chdir):
+    """Ask pipenv for a virtual environment and maybe resolve the linter."""
+    # Some pre-checks bc `pipenv` is super slow
+    project_path = get_project_path()
+    if not project_path:
+        return
+
+    pipfile = os.path.join(project_path, 'Pipfile')
+    if not os.path.exists(pipfile):
+        return
+
+    # Defer the real work to another function we can cache.
+    # ATTENTION: If the user has a Pipfile, but did not (yet) installed the
+    # environment, we will cache a wrong result here.
+    return _ask_pipenv(linter_name, chdir)
+
+
+@lru_cache(maxsize=None)
+def _ask_pipenv(linter_name, chdir):
+    cmd = ['pipenv', '--venv']
+    with util.cd(chdir):
+        venv = _communicate(cmd).strip().split('\n')[-1]
+
+    if not venv:
+        return
+
+    return find_script_by_python_env(venv, linter_name)
+
+
+def _communicate(cmd):
+    """Short wrapper around subprocess.check_output to eat all errors."""
+    env = util.create_environment()
+    info = None
+
+    # On Windows, start process without a window
+    if os.name == 'nt':
+        info = subprocess.STARTUPINFO()
+        info.dwFlags |= subprocess.STARTF_USESTDHANDLES | subprocess.STARTF_USESHOWWINDOW
+        info.wShowWindow = subprocess.SW_HIDE
+
+    try:
+        return subprocess.check_output(
+            cmd, env=env, startupinfo=info, universal_newlines=True
+        )
+    except Exception as err:
+        persist.debug(
+            "executing {} failed: reason: {}".format(cmd, str(err))
+        )
+        return ''

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -396,7 +396,7 @@ class Linter(metaclass=LinterMeta):
         """
         cls.initialize()
 
-    def __init__(self, view, syntax):
+    def __init__(self, view, syntax):  # noqa: D107
         self.view = view
         self.syntax = syntax
         self.code = ''
@@ -1009,8 +1009,18 @@ class Linter(metaclass=LinterMeta):
 
     @classmethod
     def which(cls, cmd):
-        """Call util.which with this class' module and return the result."""
-        return util.which(cmd, module=getattr(cls, 'module', None))
+        """Return full path to a given executable.
+
+        This version just delegates to `util.which` but plugin authors can
+        override this method.
+
+        Note that this method will be called statically as well as per
+        instance. So you can rely on `get_view_settings` to be available.
+
+        `context_sensitive_executable_path` is guaranteed to be called per
+        instance and might be the better override point.
+        """
+        return util.which(cmd)
 
     def get_cmd(self):
         """
@@ -1023,58 +1033,53 @@ class Linter(metaclass=LinterMeta):
         Otherwise the result of build_cmd is returned.
 
         """
-        if callable(self.cmd):
-            cmd = self.cmd()
 
-            if isinstance(cmd, str):
-                cmd = shlex.split(cmd)
+        cmd = self.cmd
 
-            return self.insert_args(cmd)
-        else:
-            return self.build_cmd()
-
-    def build_cmd(self, cmd=None):
-        """
-        Return a tuple with the command line to execute.
-
-        We start with cmd or the cmd class attribute. If it is a string,
-        it is parsed with shlex.split.
-
-        If the first element of the command line matches [script]@python[version],
-        and '@python' is in the aggregated view settings, util.which is called
-        to determine the path to the script and given version of python. This
-        allows settings to override the version of python used.
-
-        Otherwise, if self.executable_path has already been calculated, that
-        is used. If not, the executable path is located with util.which.
-
-        If the path to the executable can be determined, a list of extra arguments
-        is built with build_args. If the cmd contains '*', it is replaced
-        with the extra argument list, otherwise the extra args are appended to
-        cmd.
-
-        """
-
-        cmd = cmd or self.cmd
+        if callable(cmd):
+            cmd = cmd()
 
         if isinstance(cmd, str):
             cmd = shlex.split(cmd)
         else:
             cmd = list(cmd)
 
+        # For backwards compatibility: SL3 allowed a '@python' suffix which,
+        # when set, triggered special handling. SL4 doesn't need this marker,
+        # bc all the special handling is just done in the subclass.
+        which = cmd[0]
+        if '@python' in which:
+            cmd[0] = which[:which.find('@python')]
+
+        return self.build_cmd(cmd)
+
+    def build_cmd(self, cmd):
+        """
+        Return a tuple with the command line to execute.
+
+        Tries to find an executable with its complete path for cmd and replaces
+        cmd[0] with it.
+
+        The delegates to `insert_args` and returns whatever it returns.
+
+        """
         which = cmd[0]
         have_path, path = self.context_sensitive_executable_path(cmd)
 
         if have_path:
-            # Returning None means the linter runs code internally
-            if path == '<builtin>':
-                return None
+            # happy path
+            ...
+        elif util.can_exec(which):
+            # If `cmd` is a method, it is expected it finds an executable on
+            # its own. (Unless `context_sensitive_executable_path` is also
+            # implemented.)
+            path = which
         elif self.executable_path:
+            # `executable_path` is set statically by `can_lint`.
             path = self.executable_path
-
-            if isinstance(path, (list, tuple)) and None in path:
-                path = None
         else:
+            # `which` here is a fishy escape hatch bc it was almost always
+            # asked in `can_lint` already.
             path = self.which(which)
 
         if not path:
@@ -1089,6 +1094,11 @@ class Linter(metaclass=LinterMeta):
         Calculate the context-sensitive executable path, return a tuple of (have_path, path).
 
         Subclasses may override this to return a special path.
+
+        Return (True, '<path>') if you can resolve the executable given at cmd[0]
+        Return (True, None) if you want to skip the linter
+        Return (False, None) if you want to kick in the default implementation
+            of SublimeLinter
 
         """
         return False, None
@@ -1226,42 +1236,6 @@ class Linter(metaclass=LinterMeta):
 
         return args
 
-    def build_options(self, options, type_map, transform=None):
-        """
-        Build a list of options to be passed directly to a linting method.
-
-        This method is designed for use with linters that do linting directly
-        in code and need to pass a dict of options.
-
-        options is the starting dict of options. For each of the settings
-        listed in self.args_map:
-
-        - See if the setting name is in view settings.
-
-        - If so, and the value is non-empty, see if the setting
-          name is in type_map. If so, convert the value to the type
-          of the value in type_map.
-
-        - If transform is not None, pass the name to it and assign to the result.
-
-        - Add the name/value pair to options.
-
-        """
-
-        view_settings = self.get_view_settings(inline=True)
-
-        for name, info in self.args_map.items():
-            value = view_settings.get(name)
-
-            if value:
-                value = util.convert_type(value, type_map.get(name), sep=info.get('sep'))
-
-                if value is not None:
-                    if transform:
-                        name = transform(name)
-
-                    options[name] = value
-
     def get_chdir(self, settings):
         """Find the chdir to use with the linter."""
         chdir = settings.get('chdir', None)
@@ -1275,7 +1249,7 @@ class Linter(metaclass=LinterMeta):
             else:
                 return os.path.realpath('.')
 
-    def get_error_type(self, error, warning):
+    def get_error_type(self, error, warning):  # noqa:D102
         if error:
             return ERROR
         elif warning:
@@ -1300,18 +1274,11 @@ class Linter(metaclass=LinterMeta):
         if self.disabled:
             return
 
-        if self.cmd is None:
-            cmd = None
-        else:
-            cmd = self.get_cmd()
-
-            if cmd is not None and not cmd:
-                return
-
+        cmd = self.get_cmd()
         settings = self.get_view_settings()
-        self.chdir = self.get_chdir(settings)
+        chdir = self.get_chdir(settings)
 
-        with util.cd(self.chdir):
+        with util.cd(chdir):
             output = self.run(cmd, self.code)
 
         if not output:
@@ -1364,12 +1331,12 @@ class Linter(metaclass=LinterMeta):
                     )
                 elif near:
                     col, length = self.highlight.near(
-                            line,
-                            near,
-                            error_type=error_type,
-                            word_re=self.word_re,
-                            style=style
-                        )
+                        line,
+                        near,
+                        error_type=error_type,
+                        word_re=self.word_re,
+                        style=style
+                    )
                 else:
                     if (
                         persist.settings.get('no_column_highlights_line') or
@@ -1444,27 +1411,18 @@ class Linter(metaclass=LinterMeta):
 
         if can:
             if cls.executable_path is None:
-                executable = ''
+                executable = None
+                cmd = cls.cmd
 
-                if not callable(cls.cmd):
-                    if isinstance(cls.cmd, (tuple, list)):
-                        executable = (cls.cmd or [''])[0]
-                    elif isinstance(cls.cmd, str):
-                        executable = cls.cmd
-
-                if not executable and cls.executable:
+                if cmd and not callable(cmd):
+                    if isinstance(cls.cmd, str):
+                        cmd = shlex.split(cmd)
+                    executable = cmd[0]
+                else:
                     executable = cls.executable
 
                 if executable:
                     cls.executable_path = cls.which(executable) or ''
-
-                    if (
-                        cls.executable_path is None or
-                        (isinstance(cls.executable_path, (tuple, list)) and None in cls.executable_path)
-                    ):
-                        cls.executable_path = ''
-                elif cls.cmd is None:
-                    cls.executable_path = '<builtin>'
                 else:
                     cls.executable_path = ''
 
@@ -1520,26 +1478,10 @@ class Linter(metaclass=LinterMeta):
 
         """
 
-        cls.executable_version = None
-
-        if cls.executable_path == '<builtin>':
-            if callable(getattr(cls, 'get_module_version', None)):
-                if not(cls.version_re and cls.version_requirement):
-                    return True
-
-                cls.executable_version = cls.get_module_version()
-
-                if cls.executable_version:
-                    persist.debug('{} version: {}'.format(cls.name, cls.executable_version))
-                else:
-                    util.printf('WARNING: {} unable to determine module version'.format(cls.name))
-            else:
-                return True
-        elif not(cls.version_args is not None and cls.version_re and cls.version_requirement):
+        if not(cls.version_args is not None and cls.version_re and cls.version_requirement):
             return True
 
-        if cls.executable_version is None:
-            cls.executable_version = cls.get_executable_version()
+        cls.executable_version = cls.get_executable_version()
 
         if cls.executable_version:
             predicate = VersionPredicate(
@@ -1679,7 +1621,7 @@ class Linter(metaclass=LinterMeta):
             util.printf('{}: {} {}'.format(
                 self.name,
                 os.path.basename(self.filename or '<unsaved>'),
-                cmd or '<builtin>')
+                cmd)
             )
 
         if self.tempfile_suffix:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -39,7 +39,7 @@ class LinterMeta(type):
         if bases:
             setattr(cls, 'disabled', False)
 
-            if name in ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter'):
+            if name in ('PythonLinter', 'NewPythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter'):
                 return
 
             cls.alt_name = cls.make_alt_name(name)

--- a/lint/util.py
+++ b/lint/util.py
@@ -1,7 +1,6 @@
 """This module provides general utility methods."""
 
 from functools import lru_cache
-from glob import glob
 import json
 import locale
 from numbers import Number
@@ -12,7 +11,6 @@ import shutil
 import stat
 import sublime
 import subprocess
-import sys
 import tempfile
 
 
@@ -30,7 +28,6 @@ STREAM_BOTH = STREAM_STDOUT + STREAM_STDERR
 
 PYTHON_CMD_RE = re.compile(
     r'(?P<script>[^@]+)?@python(?P<version>[\d\.]+|.+)?')
-VERSION_RE = re.compile(r'(?P<major>\d+)(?:\.(?P<minor>\d+))?')
 
 INLINE_SETTINGS_RE = re.compile(
     r'(?i).*?\[sublimelinter[ ]+(?P<settings>[^\]]+)\]')
@@ -507,295 +504,32 @@ def can_exec(path):
 
 
 @lru_cache(maxsize=None)
-def which(cmd, module=None):
-    """
-    Return the full path to the given command, or None if not found.
+def which(cmd):
+    """Return the full path to an executable searching PATH."""
+    for path in find_executables(cmd):
+        return path
 
-    If cmd is in the form [script]@python[version], find_python is
-    called to locate the appropriate version of python. If an executable
-    version of the script can be found, its path is returned. Otherwise
-    the result is a tuple of the full python path and the full path to the script
-    (or None if there is no script).
-
-    """
-
-    match = PYTHON_CMD_RE.match(cmd)
-
-    if match:
-        args = match.groupdict()
-        args['module'] = module
-        path = find_python(**args)[0:2]
-
-        # If a script is requested and an executable path is returned
-        # with no script path, just use the executable.
-        if (
-            path is not None and
-            path[0] is not None and
-            path[1] is None and
-            args['script']  # for the case where there is no script in cmd
-        ):
-            return path[0]
-        else:
-            return path
-    else:
-        return find_executable(cmd)
+    return None
 
 
-def extract_major_minor_version(version):
-    """Extract and return major and minor versions from a string version."""
+def find_executables(executable):
+    """Yield full paths to given executable."""
+    env = create_environment()
 
-    match = VERSION_RE.match(version)
+    for base in env.get('PATH', '').split(os.pathsep):
+        path = os.path.join(os.path.expanduser(base), executable)
 
-    if match:
-        return {key: int(value) if value is not None else None for key, value in match.groupdict().items()}
-    else:
-        return {'major': None, 'minor': None}
+        # On Windows, if path does not have an extension, try .exe, .cmd, .bat
+        if sublime.platform() == 'windows' and not os.path.splitext(path)[1]:
+            for extension in ('.exe', '.cmd', '.bat'):
+                path_ext = path + extension
 
+                if can_exec(path_ext):
+                    yield path_ext
+        elif can_exec(path):
+            yield path
 
-@lru_cache(maxsize=None)
-def get_python_version(path):
-    """Return a dict with the major/minor version of the python at path."""
-
-    try:
-        # Different python versions use different output streams, so check both
-        output = communicate((path, '-V'), '', output_stream=STREAM_BOTH)
-
-        # 'python -V' returns 'Python <version>', extract the version number
-        return extract_major_minor_version(output.split(' ')[1])
-    except Exception as ex:
-        printf(
-            'ERROR: an error occurred retrieving the version for {}: {}'
-            .format(path, str(ex)))
-
-        return {'major': None, 'minor': None}
-
-
-@lru_cache(maxsize=None)
-def find_python(version=None, script=None, module=None):
-    """
-    Return the path to and version of python and an optional related script.
-
-    If not None, version should be a string/numeric version of python to locate, e.g.
-    '3' or '3.3'. Only major/minor versions are examined. This method then does
-    its best to locate a version of python that satisfies the requested version.
-    If module is not None, Sublime Text's python version is tested against the
-    requested version.
-
-    If version is None, the path to the default system python is used, unless
-    module is not None, in which case '<builtin>' is returned.
-
-    If not None, script should be the name of a python script that is typically
-    installed with easy_install or pip, e.g. 'pep8' or 'pyflakes'.
-
-    A tuple of the python path, script path, major version, minor version is returned.
-
-    """
-
-    from . import persist
-    persist.debug(
-        'find_python(version={!r}, script={!r}, module={!r})'
-        .format(version, script, module)
-    )
-
-    path = None
-    script_path = None
-
-    requested_version = {'major': None, 'minor': None}
-
-    if module is None:
-        available_version = {'major': None, 'minor': None}
-    else:
-        available_version = {
-            'major': sys.version_info.major,
-            'minor': sys.version_info.minor
-        }
-
-    if version is None:
-        # If no specific version is requested and we have a module,
-        # assume the linter will run using ST's python.
-        if module is not None:
-            result = ('<builtin>', script,
-                      available_version['major'], available_version['minor'])
-            persist.debug('find_python: <=', repr(result))
-            return result
-
-        # No version was specified, get the default python
-        path = find_executable('python')
-        persist.debug('find_python: default python =', path)
-    elif os.path.isfile(version):
-        # Specified version is a path to an executable, use it instead.
-        path = version
-    else:
-        version = str(version)
-        requested_version = extract_major_minor_version(version)
-        persist.debug('find_python: requested version =',
-                      repr(requested_version))
-
-        # If there is no module, we will use a system python.
-        # If there is a module, a specific version was requested,
-        # and the builtin version does not fulfill the request,
-        # use the system python.
-        if module is None:
-            need_system_python = True
-        else:
-            persist.debug('find_python: available version =',
-                          repr(available_version))
-            need_system_python = not version_fulfills_request(
-                available_version, requested_version)
-            path = '<builtin>'
-
-        if need_system_python:
-            if sublime.platform() in ('osx', 'linux'):
-                path = find_posix_python(version)
-            else:
-                path = find_windows_python(version)
-
-            persist.debug('find_python: system python =', path)
-
-    if path and path != '<builtin>':
-        available_version = get_python_version(path)
-        persist.debug('find_python: available version =',
-                      repr(available_version))
-
-        if version_fulfills_request(available_version, requested_version):
-            if script:
-                script_path = find_python_script(path, script)
-                persist.debug('find_python: {!r} path = {}'.format(
-                    script, script_path))
-
-                if script_path is None:
-                    path = None
-                elif script_path.endswith('.exe'):
-                    path = script_path
-                    script_path = None
-        else:
-            path = script_path = None
-
-    result = (path, script_path,
-              available_version['major'], available_version['minor'])
-    persist.debug('find_python: <=', repr(result))
-    return result
-
-
-def version_fulfills_request(available_version, requested_version):
-    """
-    Return whether available_version fulfills requested_version.
-
-    Both are dicts with 'major' and 'minor' items.
-
-    """
-
-    # No requested major version is fulfilled by anything
-    if requested_version['major'] is None:
-        return True
-
-    # If major version is requested, that at least must match
-    if requested_version['major'] != available_version['major']:
-        return False
-
-    # Major version matches, if no requested minor version it's a match
-    if requested_version['minor'] is None:
-        return True
-
-    # If a minor version is requested, the available minor version must be >=
-    return (
-        available_version['minor'] is not None and
-        available_version['minor'] >= requested_version['minor']
-    )
-
-
-@lru_cache(maxsize=None)
-def find_posix_python(version):
-    """Find the nearest version of python and return its path."""
-
-    from . import persist
-
-    if version:
-        # Try the exact requested version first
-        path = find_executable('python' + version)
-        persist.debug(
-            'find_posix_python: python{} => {}'.format(version, path))
-
-        # If that fails, try the major version
-        if not path:
-            path = find_executable('python' + version[0])
-            persist.debug(
-                'find_posix_python: python{} => {}'.format(version[0], path))
-
-            # If the major version failed, see if the default is available
-            if not path:
-                path = find_executable('python')
-                persist.debug('find_posix_python: python =>', path)
-    else:
-        path = find_executable('python')
-        persist.debug('find_posix_python: python =>', path)
-
-    return path
-
-
-@lru_cache(maxsize=None)
-def find_windows_python(version):
-    """Find the nearest version of python and return its path."""
-
-    if version:
-        # On Windows, there may be no separately named python/python3 binaries,
-        # so it seems the only reliable way to check for a given version is to
-        # check the root drive for 'Python*' directories, and try to match the
-        # version based on the directory names. The 'Python*' directories end
-        # with the <major><minor> version number, so for matching with the version
-        # passed in, strip any decimal points.
-        stripped_version = version.replace('.', '')
-        prefix = os.path.abspath(os.path.join(
-            os.environ.get("SYSTEMROOT", "\\")[:2],
-            'Python'
-        ))
-        prefix_len = len(prefix)
-        dirs = sorted(glob(prefix + '*'), reverse=True)
-        from . import persist
-
-        # Try the exact version first, then the major version
-        for version in (stripped_version, stripped_version[0]):
-            for python_dir in dirs:
-                path = os.path.join(python_dir, 'python.exe')
-                python_version = python_dir[prefix_len:]
-                persist.debug('find_windows_python: matching =>', path)
-
-                # Try the exact version first, then the major version
-                if python_version.startswith(version) and can_exec(path):
-                    persist.debug('find_windows_python: <=', path)
-                    return path
-
-    # No version or couldn't find a version match, try the default python
-    path = find_executable('python')
-    persist.debug('find_windows_python: <=', path)
-    return path
-
-
-@lru_cache(maxsize=None)
-def find_python_script(python_path, script):
-    """Return the path to the given script, or None if not found."""
-    if sublime.platform() in ('osx', 'linux'):
-        pyenv = which('pyenv')
-        if pyenv:
-            out = run_shell_cmd((os.environ['SHELL'], '-l', '-c',
-                                 'echo ""; {} which {}'.format(pyenv, script))).strip().decode().split('\n')[-1]
-            if os.path.isfile(out):
-                return out
-        return which(script)
-    else:
-        # On Windows, scripts may be .exe files or .py files in <python directory>/Scripts
-        scripts_path = os.path.join(os.path.dirname(python_path), 'Scripts')
-        script_path = os.path.join(scripts_path, script + '.exe')
-
-        if os.path.exists(script_path):
-            return script_path
-
-        script_path = os.path.join(scripts_path, script + '-script.py')
-
-        if os.path.exists(script_path):
-            return script_path
-
-        return None
+    return None
 
 
 @lru_cache(maxsize=None)
@@ -824,34 +558,6 @@ def get_python_paths():
         paths = []
 
     return paths
-
-
-@lru_cache(maxsize=None)
-def find_executable(executable):
-    """
-    Return the path to the given executable, or None if not found.
-
-    create_environment is used to augment PATH before searching
-    for the executable.
-
-    """
-
-    env = create_environment()
-
-    for base in env.get('PATH', '').split(os.pathsep):
-        path = os.path.join(os.path.expanduser(base), executable)
-
-        # On Windows, if path does not have an extension, try .exe, .cmd, .bat
-        if sublime.platform() == 'windows' and not os.path.splitext(path)[1]:
-            for extension in ('.exe', '.cmd', '.bat'):
-                path_ext = path + extension
-
-                if can_exec(path_ext):
-                    return path_ext
-        elif can_exec(path):
-            return path
-
-    return None
 
 
 # popen utils
@@ -1110,9 +816,7 @@ def clear_path_caches():
     """Clear the caches of all path-related methods in this module that use an lru_cache."""
     create_environment.cache_clear()
     which.cache_clear()
-    find_python.cache_clear()
     get_python_paths.cache_clear()
-    find_executable.cache_clear()
 
 
 def convert_type(value, type_value, sep=None, default=None):


### PR DESCRIPTION
Instead of #713 

#713 was a non-breaking change bc it only added. It was asked to do a breaking change instead based on the `next` branch.

The PR replaces the old PythonLinter with the new one used by flake8. 

❗️  It removes the ability to use the internal python for linting. So basically all ol'school plugins should be broken. ❗️ The last save commit is https://github.com/SublimeLinter/SublimeLinter3/commit/3c63751fbcefac8905376729e69f6ef5fc27eb78 bc after that the removal process begins.

- For compatibility, a cmd = ['flake8@python', ...] is allowed, but it is not needed, and in fact we have to strip it away. (https://github.com/SublimeLinter/SublimeLinter3/commit/ff7e9f9caa735302265b960d8a8c2b180d7943bb)



 