### PR TITLE
Confirm to `context_sensitive_executable_path` type

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -57,15 +57,10 @@ class ComposerLinter(linter.Linter):
             local_cmd = self.find_local_cmd_path(cmd[0])
 
         if not local_cmd and not global_cmd:
-            util.printf(
-                'WARNING: {} deactivated, cannot locate local or global binary'
-                .format(self.name, cmd[0])
-            )
-            return False, ''
+            return True, None
 
         composer_cmd_path = local_cmd if local_cmd else global_cmd
-        self.executable_path = composer_cmd_path
-        return False, composer_cmd_path
+        return True, composer_cmd_path
 
     def get_manifest_path(self):
         """Get the path to the composer.json file for the current file."""

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -108,15 +108,10 @@ class NodeLinter(linter.Linter):
             local_cmd = self.find_local_cmd_path(cmd[0])
 
         if not local_cmd and not global_cmd:
-            util.printf(
-                'WARNING: {} deactivated, cannot locate local or global binary'
-                .format(self.name, cmd[0])
-            )
-            return False, ''
+            return True, None
 
         node_cmd_path = local_cmd if local_cmd else global_cmd
-        self.executable_path = node_cmd_path
-        return False, node_cmd_path
+        return True, node_cmd_path
 
     def get_manifest_path(self):
         """Get the path to the package.json file for the current file."""

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1086,7 +1086,7 @@ class Linter(metaclass=LinterMeta):
             path = self.which(which)
 
         if not path:
-            util.printf('ERROR: {} cannot locate \'{}\''.format(self.name, which))
+            util.printf('WARNING: {} cannot locate \'{}\''.format(self.name, which))
             return ''
 
         cmd[0:1] = util.convert_type(path, [])


### PR DESCRIPTION
`context_sensitive_executable_path` should return

	(True, None) if it cannot find an executable
	(True, <path>) if it has an executable path
	(False, None) if it wants the default behavior of the standard linter

If we return (False, '') we basically just do a `which(cmd[0])` again.
If we return (False, \<path>), the returned '\<path>' is actually ignored.